### PR TITLE
test: ensure async/await is used for dotNetRDF tests

### DIFF
--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/RdfXmlMediaTypeFormatterTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/RdfXmlMediaTypeFormatterTests.cs
@@ -141,7 +141,7 @@ public class RdfXmlMediaTypeFormatterTests
     }
 
     [Fact]
-    public async Task TestTurtleSerialization()
+    public async Task TestTurtleSerializationAsync()
     {
         var changeRequest1 = new ChangeRequest(new Uri("http://com/somewhere/changeReuest"));
 

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/RdfXmlMediaTypeFormatterTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/RdfXmlMediaTypeFormatterTests.cs
@@ -169,8 +169,8 @@ public class RdfXmlMediaTypeFormatterTests
     private static async Task<string> SerializeAsync<T>(MediaTypeFormatter formatter, T value,
         MediaTypeHeaderValue mediaType)
     {
-        Stream stream = new MemoryStream();
-        HttpContent content = new StreamContent(stream);
+        await using Stream stream = new MemoryStream();
+        using HttpContent content = new StreamContent(stream);
 
         content.Headers.ContentType = mediaType;
 
@@ -183,8 +183,8 @@ public class RdfXmlMediaTypeFormatterTests
     private static async Task<string> SerializeCollectionAsync<T>(MediaTypeFormatter formatter,
         IEnumerable<T> value, MediaTypeHeaderValue mediaType)
     {
-        Stream stream = new MemoryStream();
-        HttpContent content = new StreamContent(stream);
+        await using Stream stream = new MemoryStream();
+        using HttpContent content = new StreamContent(stream);
 
         content.Headers.ContentType = mediaType;
 
@@ -197,9 +197,9 @@ public class RdfXmlMediaTypeFormatterTests
     private static async Task<T?> DeserializeAsync<T>(MediaTypeFormatter formatter, string str,
         MediaTypeHeaderValue mediaType) where T : class
     {
-        Stream stream = new MemoryStream();
-        var writer = new StreamWriter(stream);
-        HttpContent content = new StreamContent(stream);
+        await using Stream stream = new MemoryStream();
+        await using var writer = new StreamWriter(stream);
+        using HttpContent content = new StreamContent(stream);
 
         content.Headers.ContentType = mediaType;
 
@@ -215,9 +215,9 @@ public class RdfXmlMediaTypeFormatterTests
         MediaTypeFormatter formatter,
         string str, MediaTypeHeaderValue mediaType) where T : class
     {
-        Stream stream = new MemoryStream();
-        var writer = new StreamWriter(stream);
-        HttpContent content = new StreamContent(stream);
+        await using Stream stream = new MemoryStream();
+        await using var writer = new StreamWriter(stream);
+        using HttpContent content = new StreamContent(stream);
 
         content.Headers.ContentType = mediaType;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated test methods to use asynchronous patterns.
	- Improved error handling and null checks in test methods.

- **Refactor**
	- Replaced synchronous method calls with async/await implementations.
	- Updated method signatures to reflect asynchronous nature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->