### PR TITLE
refactor: drop log4net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This release does not contain security updates.
       codes `OSLCC001..OSLCC004` from Client were renamed into
       `OSLC2001..OSLC2014`. All OSLC4Net error codes now have 4 digits for
       consistency.
+- DotNetRdfHelper is no longer static
 
 ### Deprecated
 
@@ -46,6 +47,10 @@ This release does not contain security updates.
   the JSON-LD support is added.
 - I18n resource strings were removed along with the corresponding
   constructors on exceptions. Also, `MessageExtractor` helpers were removed.
+- log4net dependency - all logging is now done via standard `ILogger`
+  abstraction.
+- ServiceProviderRegistryURIs - oslc4net will no longer try to guess/compute the
+  SP catalog URI.
 
 ### Fixed
 

--- a/OSLC4Net_NETFramework/OSLC4Net.Client.Samples/OSLC4Net.Client.Samples.csproj
+++ b/OSLC4Net_NETFramework/OSLC4Net.Client.Samples/OSLC4Net.Client.Samples.csproj
@@ -92,9 +92,6 @@
     <WCFMetadata Include="Connected Services\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="log4net">
-      <Version>2.0.15</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client">
       <Version>5.2.9</Version>
     </PackageReference>
@@ -106,7 +103,7 @@
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/OSLC4Net_SDK/Directory.Packages.props
+++ b/OSLC4Net_SDK/Directory.Packages.props
@@ -10,7 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- For removal -->
-    <PackageVersion Include="log4net" Version="3.1.0"/>
     <PackageVersion Include="NuGet.Build.Tasks.Pack" Version="6.12.1"/>
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageVersion Include="System.Json" Version="4.8.0"/>

--- a/OSLC4Net_SDK/OSLC4Net.ChangeManagement/OSLC4Net.ChangeManagementCommon.csproj
+++ b/OSLC4Net_SDK/OSLC4Net.ChangeManagement/OSLC4Net.ChangeManagementCommon.csproj
@@ -13,6 +13,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" />
-    <PackageReference Include="log4net"/>
   </ItemGroup>
 </Project>

--- a/OSLC4Net_SDK/OSLC4Net.Client/OSLC4Net.Client.csproj
+++ b/OSLC4Net_SDK/OSLC4Net.Client/OSLC4Net.Client.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="CommunityToolkit.Diagnostics"/>
     <PackageReference Include="dotNetRdf.Core"/>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client"/>
-    <PackageReference Include="log4net"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
   </ItemGroup>
 </Project>

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQuery.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQuery.cs
@@ -13,6 +13,8 @@
  *     Steve Pitschke  - initial API and implementation
  *******************************************************************************/
 
+using OSLC4Net.Core.DotNetRdfProvider;
+
 namespace OSLC4Net.Client.Oslc.Resources;
 
 /// <summary>
@@ -21,6 +23,7 @@ namespace OSLC4Net.Client.Oslc.Resources;
 /// </summary>
 public class OslcQuery
 {
+    private readonly DotNetRdfHelper _rdfHelper;
     private readonly string capabilityUrl;
     private readonly string orderBy;
     private readonly OslcClient oslcClient;
@@ -42,9 +45,11 @@ public class OslcQuery
     /// </summary>
     /// <param name="oslcClient">the authenticated OSLC client</param>
     /// <param name="capabilityUrl">the URL that is the base </param>
-    public OslcQuery(OslcClient oslcClient, string capabilityUrl) :
+    public OslcQuery(OslcClient oslcClient, string capabilityUrl,
+        DotNetRdfHelper? rdfHelper = null) :
         this(oslcClient, capabilityUrl, 0)
     {
+        _rdfHelper = rdfHelper ?? Activator.CreateInstance<DotNetRdfHelper>();
     }
 
     /// <summary>
@@ -174,7 +179,8 @@ public class OslcQuery
 
     public async Task<OslcQueryResult> Submit()
     {
-        return new OslcQueryResult(this, await GetResponseRawAsync().ConfigureAwait(false));
+        return new OslcQueryResult(this, await GetResponseRawAsync().ConfigureAwait(false),
+            _rdfHelper);
     }
 
     internal Task<HttpResponseMessage> GetResponseRawAsync()

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryParameters.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryParameters.cs
@@ -13,8 +13,6 @@
  *     Steve Pitschke  - initial API and implementation
  *******************************************************************************/
 
-using log4net;
-
 namespace OSLC4Net.Client.Oslc.Resources;
 
 /// <summary>
@@ -27,8 +25,6 @@ public class OslcQueryParameters
     private string? _searchTerms;
     private string? _orderBy;
     private string? _prefix;
-
-    private static readonly ILog _logger = LogManager.GetLogger(typeof(OslcQuery));
 
     public OslcQueryParameters()
     {

--- a/OSLC4Net_SDK/OSLC4Net.Client/ServiceProviderRegistryClient.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/ServiceProviderRegistryClient.cs
@@ -44,7 +44,7 @@ public sealed class ServiceProviderRegistryClient
     /// <param name="username">Basic auth username</param>
     /// <param name="password">Basic auth password</param>
     public ServiceProviderRegistryClient(string uri,
-        IEnumerable<MediaTypeFormatter> formatters,
+        IEnumerable<MediaTypeFormatter>? formatters,
         string mediaType,
         ILoggerFactory loggerFactory,
         string? username = null,
@@ -67,29 +67,23 @@ public sealed class ServiceProviderRegistryClient
     /// <param name="formatters"></param>
     /// <param name="mediaType"></param>
     public ServiceProviderRegistryClient(string uri,
-        IEnumerable<MediaTypeFormatter> formatters,
+        IEnumerable<MediaTypeFormatter>? formatters,
         string mediaType, ILoggerFactory loggerFactory) : this(uri, formatters, mediaType,
         loggerFactory, null)
     {
     }
 
-    public ServiceProviderRegistryClient(string uri, IEnumerable<MediaTypeFormatter> formatters,
-        ILoggerFactory loggerFactory) :
+    public ServiceProviderRegistryClient(string uri,
+        ILoggerFactory loggerFactory, IEnumerable<MediaTypeFormatter>? formatters = null) :
         this(uri, formatters, OslcMediaType.APPLICATION_RDF_XML, loggerFactory, null)
     {
     }
 
-    public ServiceProviderRegistryClient(string uri, ILoggerFactory loggerFactory) :
-        // TODO: build an Accept string from the formatter list on the fly
-        this(uri, OslcRestClient.DEFAULT_FORMATTERS, OslcMediaType.APPLICATION_RDF_XML,
-            loggerFactory, null)
-    {
-    }
 
     public static ServiceProviderRegistryClient WithBasicAuth(string uri, string username,
         string password, ILoggerFactory loggerFactory)
     {
-        return new ServiceProviderRegistryClient(uri, OslcRestClient.DEFAULT_FORMATTERS,
+        return new ServiceProviderRegistryClient(uri, null,
             OslcMediaType.APPLICATION_RDF_XML, loggerFactory, username, password);
     }
 

--- a/OSLC4Net_SDK/OSLC4Net.Client/ServiceProviderRegistryURIs.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/ServiceProviderRegistryURIs.cs
@@ -14,72 +14,68 @@
  *******************************************************************************/
 
 
-using System.Net.NetworkInformation;
-using log4net;
-
 namespace OSLC4Net.Client;
 
 /// <summary>
 /// This class calculates and store a ServiceProvider Registry URI.
 /// </summary>
-public static class ServiceProviderRegistryURIs
-{
-    private static readonly ILog LOGGER = LogManager.GetLogger(typeof(ServiceProviderRegistryURIs));
-
-    private static readonly string SYSTEM_PROPERTY_NAME_REGISTRY_URI =
-        typeof(ServiceProviderRegistryURIs).Assembly.FullName + ".registryuri";
-
-    private static readonly string SERVICE_PROVIDER_REGISTRY_URI;
-
-    static ServiceProviderRegistryURIs()
-    {
-        LOGGER.Debug($"Checking {SYSTEM_PROPERTY_NAME_REGISTRY_URI} env var for OSLC SPC URI");
-        var registryURI = Environment.GetEnvironmentVariable(SYSTEM_PROPERTY_NAME_REGISTRY_URI);
-
-        string? defaultBase = null;
-
-        if (registryURI == null)
-        {
-            // We need at least one default URI
-
-            var hostName = "localhost";
-
-            try
-            {
-                hostName = IPGlobalProperties.GetIPGlobalProperties().HostName;
-            }
-            catch (Exception)
-            {
-                // Default to localhost
-            }
-
-            defaultBase = "http://" + hostName + ":8080/";
-        }
-
-        if (registryURI != null)
-        {
-            SERVICE_PROVIDER_REGISTRY_URI = registryURI;
-        }
-        else
-        {
-            // In order to force Jena to show SPC first in XML, add a bogus identifier to the SPC URI.
-            // This is because Jena can show an object anywhere in its graph where it is referenced.  Since the
-            // SPC URI (without tailing identifier) is the same as its QueryCapability's queryBase, it can
-            // be strangely rendered with the SPC nested under the queryBase.
-            // This also allows us to distinguish between array and single results within the ServiceProviderCatalogResource.
-            SERVICE_PROVIDER_REGISTRY_URI = defaultBase + "OSLC4JRegistry/catalog/singleton";
-
-            LOGGER.Warn("System property '" + SYSTEM_PROPERTY_NAME_REGISTRY_URI +
-                        "' not set.  Using calculated value '" + SERVICE_PROVIDER_REGISTRY_URI + "'");
-        }
-    }
-
-    /// <summary>
-    /// Get a "global"/"root" ServiceProviderRegistry URI - not part of the OSLC standard.
-    /// </summary>
-    /// <returns></returns>
-    public static string getGlobalServiceProviderRegistryURI()
-    {
-        return SERVICE_PROVIDER_REGISTRY_URI;
-    }
-}
+// public static class ServiceProviderRegistryURIs
+// {
+//
+//     // private static readonly string SYSTEM_PROPERTY_NAME_REGISTRY_URI =
+//     //     typeof(ServiceProviderRegistryURIs).Assembly.FullName + ".registryuri";
+//
+//     private static readonly string SERVICE_PROVIDER_REGISTRY_URI;
+//
+//     static ServiceProviderRegistryURIs()
+//     {
+//         LOGGER.Debug($"Checking {SYSTEM_PROPERTY_NAME_REGISTRY_URI} env var for OSLC SPC URI");
+//         var registryURI = Environment.GetEnvironmentVariable(SYSTEM_PROPERTY_NAME_REGISTRY_URI);
+//
+//         string? defaultBase = null;
+//
+//         if (registryURI == null)
+//         {
+//             // We need at least one default URI
+//
+//             var hostName = "localhost";
+//
+//             try
+//             {
+//                 hostName = IPGlobalProperties.GetIPGlobalProperties().HostName;
+//             }
+//             catch (Exception)
+//             {
+//                 // Default to localhost
+//             }
+//
+//             defaultBase = "http://" + hostName + ":8080/";
+//         }
+//
+//         if (registryURI != null)
+//         {
+//             SERVICE_PROVIDER_REGISTRY_URI = registryURI;
+//         }
+//         else
+//         {
+//             // In order to force Jena to show SPC first in XML, add a bogus identifier to the SPC URI.
+//             // This is because Jena can show an object anywhere in its graph where it is referenced.  Since the
+//             // SPC URI (without tailing identifier) is the same as its QueryCapability's queryBase, it can
+//             // be strangely rendered with the SPC nested under the queryBase.
+//             // This also allows us to distinguish between array and single results within the ServiceProviderCatalogResource.
+//             SERVICE_PROVIDER_REGISTRY_URI = defaultBase + "OSLC4JRegistry/catalog/singleton";
+//
+//             LOGGER.Warn("System property '" + SYSTEM_PROPERTY_NAME_REGISTRY_URI +
+//                         "' not set.  Using calculated value '" + SERVICE_PROVIDER_REGISTRY_URI + "'");
+//         }
+//     }
+//
+//     /// <summary>
+//     /// Get a "global"/"root" ServiceProviderRegistry URI - not part of the OSLC standard.
+//     /// </summary>
+//     /// <returns></returns>
+//     public static string getGlobalServiceProviderRegistryURI()
+//     {
+//         return SERVICE_PROVIDER_REGISTRY_URI;
+//     }
+// }

--- a/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/DotNetRdfHelper.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/DotNetRdfHelper.cs
@@ -20,7 +20,8 @@ using System.Numerics;
 using System.Reflection;
 using System.Xml.Linq;
 using CommunityToolkit.Diagnostics;
-using log4net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using OSLC4Net.Core.Attribute;
 using OSLC4Net.Core.Exceptions;
 using OSLC4Net.Core.Model;
@@ -34,8 +35,14 @@ namespace OSLC4Net.Core.DotNetRdfProvider;
 /// <summary>
 ///     A class to assist with serialization and de-serialization of RDF/XML from/to .NET objects
 /// </summary>
-public static class DotNetRdfHelper
+public class DotNetRdfHelper(ILogger<DotNetRdfHelper> logger)
 {
+    public DotNetRdfHelper() : this(NullLoggerFactory.Instance.CreateLogger<DotNetRdfHelper>())
+    {
+    }
+
+    private readonly ILogger<DotNetRdfHelper> _logger =
+        logger;
     private const string PROPERTY_TOTAL_COUNT = "totalCount";
     private const string PROPERTY_NEXT_PAGE = "nextPage";
 
@@ -55,8 +62,6 @@ public static class DotNetRdfHelper
 
     private static readonly int METHOD_NAME_START_GET_LENGTH = METHOD_NAME_START_GET.Length;
     private static readonly int METHOD_NAME_START_IS_LENGTH = METHOD_NAME_START_IS.Length;
-
-    private static readonly ILog logger = LogManager.GetLogger(typeof(DotNetRdfHelper));
 
     /// <summary>
     ///     Create an RDF graph from a collection of .NET objects
@@ -235,7 +240,7 @@ public static class DotNetRdfHelper
     /// <param name="resource"></param>
     /// <param name="beanType"></param>
     /// <returns></returns>
-    public static object FromDotNetRdfNode(IUriNode resource,
+    public object FromDotNetRdfNode(IUriNode resource,
         IGraph? graph,
         Type beanType)
     {
@@ -262,7 +267,7 @@ public static class DotNetRdfHelper
     /// <param name="graph"></param>
     /// <param name="beanType"></param>
     /// <returns></returns>
-    public static object FromDotNetRdfGraph(IGraph graph,
+    public object FromDotNetRdfGraph(IGraph graph,
         Type beanType)
     {
         Type[] types = { beanType };
@@ -307,7 +312,7 @@ public static class DotNetRdfHelper
         return results;
     }
 
-    private static void FromDotNetRdfNode(
+    private void FromDotNetRdfNode(
         IDictionary<Type, IDictionary<string, MemberInfo>> typePropertyDefinitionsToSetMethods,
         Type beanType,
         object bean,
@@ -393,10 +398,10 @@ public static class DotNetRdfHelper
                 {
                     if (extendedProperties == null)
                     {
-                        logger.Warn("Set method not found for object type:  " +
-                                    beanType.Name +
-                                    ", uri:  " +
-                                    uri);
+                        _logger.LogWarning("Set method not found for object type:  " +
+                                           beanType.Name +
+                                           ", uri:  " +
+                                           uri);
                     }
                     else
                     {
@@ -1000,7 +1005,7 @@ public static class DotNetRdfHelper
         return candidatePrefix;
     }
 
-    private static object HandleExtendedPropertyValue(Type beanType,
+    private object HandleExtendedPropertyValue(Type beanType,
         INode obj,
         IGraph graph,
         IDictionary<string, object> visitedResources)

--- a/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/OSLC4Net.Core.DotNetRdfProvider.csproj
+++ b/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/OSLC4Net.Core.DotNetRdfProvider.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" />
     <PackageReference Include="dotNetRdf.Inferencing"/>
-    <PackageReference Include="log4net" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="dotNetRdf.Core" />
   </ItemGroup>

--- a/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/RdfXmlMediaTypeFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/RdfXmlMediaTypeFormatter.cs
@@ -39,13 +39,15 @@ public class RdfXmlMediaTypeFormatter : MediaTypeFormatter
 {
     const int STREAM_BUFFER_SIZE = 8192;
     private HttpRequestMessage httpRequest;
+    private readonly DotNetRdfHelper _rdfHelper;
 
     /// <summary>
     ///     Defauld RdfXml formatter
     /// </summary>
     /// <param name="graph"></param>
-    public RdfXmlMediaTypeFormatter(bool rebuildgraph = true)
+    public RdfXmlMediaTypeFormatter(DotNetRdfHelper? rdfHelper = null, bool rebuildgraph = true)
     {
+        _rdfHelper = rdfHelper ?? Activator.CreateInstance<DotNetRdfHelper>();
         RebuildGraph = rebuildgraph;
 
         SupportedMediaTypes.Add(OslcMediaType.APPLICATION_RDF_XML_TYPE);
@@ -61,8 +63,9 @@ public class RdfXmlMediaTypeFormatter : MediaTypeFormatter
     /// <param name="graph"></param>
     public RdfXmlMediaTypeFormatter(
         IGraph graph,
+        DotNetRdfHelper? rdfHelper,
         bool rebuildgraph = true
-    ) : this(rebuildgraph)
+    ) : this(rdfHelper, rebuildgraph)
     {
         Graph = graph;
     }
@@ -446,7 +449,7 @@ public class RdfXmlMediaTypeFormatter : MediaTypeFormatter
 
                 var isSingleton = IsSingleton(type);
                 var output =
-                    DotNetRdfHelper.FromDotNetRdfGraph(graph,
+                    _rdfHelper.FromDotNetRdfGraph(graph,
                         isSingleton ? type : GetMemberType(type));
 
                 if (isSingleton)

--- a/OSLC4Net_SDK/OSLC4Net.Core.Query/OSLC4Net.Core.Query.csproj
+++ b/OSLC4Net_SDK/OSLC4Net.Core.Query/OSLC4Net.Core.Query.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" />
-    <PackageReference Include="log4net" />
     <PackageReference Include="Antlr3.Runtime" />
   </ItemGroup>
 </Project>

--- a/OSLC4Net_SDK/OSLC4Net.Core/OSLC4Net.Core.csproj
+++ b/OSLC4Net_SDK/OSLC4Net.Core/OSLC4Net.Core.csproj
@@ -86,6 +86,5 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics"/>
-    <PackageReference Include="log4net"/>
   </ItemGroup>
 </Project>

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/OSLC4Net.Core.DotNetRdfProviderTests.csproj
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/OSLC4Net.Core.DotNetRdfProviderTests.csproj
@@ -13,7 +13,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="log4net" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" >

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/RdfXmlMediaTypeFormatterTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/RdfXmlMediaTypeFormatterTests.cs
@@ -78,7 +78,7 @@ public class RdfXmlMediaTypeFormatterTests
                                                                crListOut,
                                                                null);
         // TODO: fix overload confusion with one arg
-        var formatter = new RdfXmlMediaTypeFormatter(rdfGraph, true);
+        var formatter = new RdfXmlMediaTypeFormatter(rdfGraph, null);
 
         var rdfXml =
             await SerializeCollectionAsync(formatter, crListOut,

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/OSLC4Net.Core.QueryTests.csproj
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/OSLC4Net.Core.QueryTests.csproj
@@ -11,7 +11,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="log4net" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Test.RefImpl/TestBase.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Test.RefImpl/TestBase.cs
@@ -66,9 +66,7 @@ public abstract class TestBase
     }
 
 
-
-    protected virtual IEnumerable<MediaTypeFormatter> Formatters { get; } =
-        OslcRestClient.DEFAULT_FORMATTERS;
+    protected virtual IEnumerable<MediaTypeFormatter> Formatters => TestClient.GetFormatters();
 
     protected Uri? ChangeRequestUri { get; set; }
     public string? Username { get; set; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Removed**
  - Eliminated the dependency on the log4net logging framework across all components.
  - Logging is now handled using Microsoft.Extensions.Logging abstractions.

- **Changed**
  - The DotNetRdfHelper class is no longer static and now uses injected logging.
  - Service provider registry URI guessing and computation have been fully disabled.
  - Media type formatter handling has been updated for improved flexibility and injection.
  - Several constructors and properties have been updated for better dependency management and extensibility.

- **Bug Fixes**
  - Improved consistency in logging and formatter usage throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->