### PR TITLE
feat: allow RDF output to be configured

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]
+  merge_group:
   schedule:
     - cron: "0 0 * * 1"
 
@@ -31,6 +32,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,9 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+  # merge_group:
 
 permissions:
   contents: read
@@ -19,6 +21,7 @@ concurrency:
 jobs:
   dependency-review:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
     branches: ["main", "master"]
   pull_request:
     branches: ["main", "master"]
+  merge_group:
   release:
     types:
       - published # Run the workflow when a new GitHub release is published
@@ -42,6 +43,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: main/OSLC4Net_SDK/
@@ -85,6 +87,7 @@ jobs:
             { setup: "10.x", target: "net10.0" },
           ]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: main/OSLC4Net_SDK/

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   rebase:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,6 +26,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/sonarcloud.yml.off
+++ b/.github/workflows/sonarcloud.yml.off
@@ -17,6 +17,7 @@ jobs:
   build:
     name: Build and analyze
     runs-on: windows-latest
+    timeout-minutes: 25
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:nolint') && !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     steps:
       - name: Set up JDK 17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This release does not contain security updates.
 
 - The `QName` class now has properties `NamespaceUri`, `LocalPart`, and
   `Prefix`.
+- ⚡️ `OslcOutputFormatConfig` configure RDF output formatting (pretty-printing, DTD, JSON-LD mode)
 
 ### Changed
 
@@ -27,7 +28,7 @@ This release does not contain other significant changes.
 
 ### Deprecated
 
-- `QName` getters `GetNamespaceURI`, `GetLocalPart`, and `GetPrefix` are
+- 👉 `QName` getters `GetNamespaceURI`, `GetLocalPart`, and `GetPrefix` are
   deprecated in favor of C# properties and are scheduled for removal in the
   next release.
 

--- a/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/RootServicesController.cs
+++ b/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/RootServicesController.cs
@@ -16,8 +16,8 @@ public class RootServicesController(ILogger<RootServicesController> logger) : Co
         {
             // Get the base URL from the current request
             var baseUrl = $"{Request.Scheme}://{Request.Host}";
-            var rootServicesUrl = $"{baseUrl}/services/rootservices";
-            var catalogUrl = $"{baseUrl}/services/catalog/singleton";
+            var rootServicesUrl = $"{baseUrl}/.well-known/oslc/rootservices.xml";
+            var catalogUrl = $"{baseUrl}/oslc/catalog";
 
             // Create the DTO with dynamic URLs based on the request
             var rootServices = new RootServicesDto

--- a/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Program.cs
+++ b/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Program.cs
@@ -14,7 +14,9 @@ builder.Services.AddControllers(options =>
             {
                 // CompressionLevel = WriterCompressionLevel.Minimal,
                 // PrettyPrint = false,
-                CompressionLevel = WriterCompressionLevel.High, PrettyPrint = true, UseDtd = true
+                CompressionLevel = WriterCompressionLevel.High,
+                PrettyPrint = true,
+                UseDtd = true
             }));
 
 });

--- a/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Program.cs
+++ b/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Program.cs
@@ -1,4 +1,5 @@
 using OSLC4Net.Server.Providers;
+using VDS.RDF.Writing;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -7,7 +8,15 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers(options =>
 {
     options.InputFormatters.Insert(0, new OslcRdfInputFormatter());
-    options.OutputFormatters.Insert(0, new OslcRdfOutputFormatter());
+    options.OutputFormatters.Insert(0,
+        new OslcRdfOutputFormatter(
+            new OslcOutputFormatConfig
+            {
+                // CompressionLevel = WriterCompressionLevel.Minimal,
+                // PrettyPrint = false,
+                CompressionLevel = WriterCompressionLevel.High, PrettyPrint = true, UseDtd = true
+            }));
+
 });
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcOutputFormatConfig.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcOutputFormatConfig.cs
@@ -1,13 +1,23 @@
 using System.Runtime.InteropServices;
 using VDS.RDF.JsonLd.Syntax;
+using VDS.RDF.Writing;
 
 namespace OSLC4Net.Server.Providers;
 
 [StructLayout(LayoutKind.Auto)]
-public struct OslcOutputFormatConfig
+public readonly struct OslcOutputFormatConfig
 {
-    public bool? PrettyPrint { get; init; }
-    public bool? UseDtd { get; init; }
-    public int? CompressionLevel { get; init; }
-    public JsonLdProcessingMode? JsonLdMode { get; init; }
+    public OslcOutputFormatConfig()
+    {
+    }
+
+    public bool PrettyPrint { get; init; } = true;
+
+    /// <summary>
+    ///     See <see cref="WriterCompressionLevel" />
+    /// </summary>
+    public int CompressionLevel { get; init; } = WriterCompressionLevel.More;
+
+    public JsonLdProcessingMode JsonLdMode { get; init; } = JsonLdProcessingMode.JsonLd11;
+    public bool UseDtd { get; init; } = false;
 }

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcOutputFormatConfig.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcOutputFormatConfig.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+using VDS.RDF.JsonLd.Syntax;
+
+namespace OSLC4Net.Server.Providers;
+
+[StructLayout(LayoutKind.Auto)]
+public struct OslcOutputFormatConfig
+{
+    public bool? PrettyPrint { get; init; }
+    public bool? UseDtd { get; init; }
+    public int? CompressionLevel { get; init; }
+    public JsonLdProcessingMode? JsonLdMode { get; init; }
+}

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
@@ -20,6 +20,11 @@ public class OslcRdfOutputFormatter : TextOutputFormatter
 {
     private readonly OslcOutputFormatConfig _config;
 
+    // From https://learn.microsoft.com/en-us/aspnet/core/web-api/advanced/custom-formatters?view=aspnetcore-9.0#specify-supported-media-types-and-encodings
+    // A formatter class can not use constructor injection for its dependencies. For example,
+    // ILogger<VcardOutputFormatter> can't be added as a parameter to the constructor. To access
+    // services, use the context object that gets passed in to the methods. A code example in this
+    // article and the sample show how to do this.
     public OslcRdfOutputFormatter(OslcOutputFormatConfig? config = null)
     {
         _config = new OslcOutputFormatConfig

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/SerializationContext.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/SerializationContext.cs
@@ -6,5 +6,4 @@ internal readonly struct SerializationContext
 {
     public IGraph Graph { get; init; }
     public RdfFormat? Format { get; init; }
-    public bool PrettyPrint { get; init; }
 }


### PR DESCRIPTION
Introduces a struct to be passed to the output writer:

```csharp
public struct OslcOutputFormatConfig
{
    public bool? PrettyPrint { get; init; }
    public bool? UseDtd { get; init; }
    public int? CompressionLevel { get; init; }
    public JsonLdProcessingMode? JsonLdMode { get; init; }
}
```

It can be used to adjust formatting settings used by dotNetRDF internally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable RDF/JSON‑LD output (compression, pretty printing, DTD, JSON‑LD mode).
  - Sample app now defaults to high compression with pretty printing.

- Refactor
  - Root Services and catalog endpoints updated to OSLC-standard well-known paths.
  - About and provider references now resolve to OSLC endpoints; OAuth endpoints unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->