### PR TITLE
fix: make StringValue public and inherit Value

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Core.Query/StringValue.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.Query/StringValue.cs
@@ -16,9 +16,9 @@
 namespace OSLC4Net.Core.Query;
 
 /// <summary>
-/// String literal operand from olsc.where clause
+/// String literal operand from oslc.where clause
 /// </summary>
-interface StringValue
+public interface StringValue : Value
 {
     string Value { get; }
 }


### PR DESCRIPTION
Closes #396 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * StringValue interface is now publicly accessible and inherits from the Value interface

* **Bug Fixes**
  * Corrected API documentation references in StringValue interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->