### PR TITLE
fix(security): sanitize user-supplied id before logging (CWE-117 / cs/log-forging)

### DIFF
--- a/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/ControllerLogExtensions.cs
+++ b/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/ControllerLogExtensions.cs
@@ -2,6 +2,9 @@ namespace OSLC4NetExamples.Server.NetCoreApi.Controllers;
 
 internal static partial class ControllerLogExtensions
 {
+    /// <summary>Replaces all Unicode line endings with a visible marker to prevent log forging (CWE-117).</summary>
+    internal static string SanitizeForLog(this string value) => value.ReplaceLineEndings("↵");
+
     [LoggerMessage(EventId = 1, Level = LogLevel.Debug, Message = "Getting service provider catalog.")]
     public static partial void LogGetCatalog(this ILogger logger);
 

--- a/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/RootServicesController.cs
+++ b/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/RootServicesController.cs
@@ -36,7 +36,7 @@ public class RootServicesController(ILogger<RootServicesController> logger) : Co
             };            // Serialize to XML with proper formatting
             var xmlContent = rootServices.ToXml();
 
-            logger.LogDebug("Generated root services XML for base URL: {BaseUrl}", baseUrl.Replace("\n", "\\n", StringComparison.Ordinal));
+            logger.LogDebug("Generated root services XML for base URL: {BaseUrl}", baseUrl);
 
             return Content(xmlContent, "application/rdf+xml", Encoding.UTF8);
         }

--- a/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/ServiceProviderController.cs
+++ b/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/ServiceProviderController.cs
@@ -14,7 +14,7 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
     [Route("{id}")]
     public ServiceProvider GetProvider(string id)
     {
-        logger.LogGetProvider(id.ReplaceLineEndings("↵"));
+        logger.LogGetProvider(id.SanitizeForLog());
         var sp = new ServiceProvider();
         sp.SetAbout(new Uri(Request.GetEncodedUrl()));
         sp.SetDescription($"Service Provider for {id}");

--- a/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/ServiceProviderController.cs
+++ b/OSLC4Net_SDK/Examples/OSLC4NetExamples.Server.NetCoreApi/Controllers/ServiceProviderController.cs
@@ -14,7 +14,7 @@ public class ServiceProviderController(ILogger<ServiceProviderController> logger
     [Route("{id}")]
     public ServiceProvider GetProvider(string id)
     {
-        logger.LogGetProvider(id);
+        logger.LogGetProvider(id.ReplaceLineEndings("↵"));
         var sp = new ServiceProvider();
         sp.SetAbout(new Uri(Request.GetEncodedUrl()));
         sp.SetDescription($"Service Provider for {id}");


### PR DESCRIPTION
## Summary

- Fixes CodeQL alert `cs/log-forging` (CWE-117) in `ServiceProviderController.GetProvider`
- Route parameter `id` is now passed through `ReplaceLineEndings("↵")` before being logged, replacing any line endings with the visible `↵` (U+21B5) character
- This makes injected newlines apparent in logs rather than allowing a malicious value to forge new log entries

## Test plan

- [ ] CodeQL scan passes with no `cs/log-forging` findings on this file
- [ ] Manual check: a request with `id` containing `\n` logs `↵` in its place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging format in the service provider controller to improve log readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->