### PR TITLE
Fix simple compiler warnings CA2208, implement IEquatable on models

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
@@ -26,7 +26,7 @@ namespace OSLC4Net.Client.Oslc.Resources;
 [OslcResourceShape(title = "Parameter Instance Resource Shape",
     describes = new string[] { AutomationConstants.TYPE_PARAMETER_INSTANCE })]
 [OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)]
-public class ParameterInstance : AbstractResource
+public class ParameterInstance : AbstractResource, IComparable<ParameterInstance>
 {
 
     private string name;

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
@@ -24,7 +24,7 @@ namespace OSLC4Net.Core.Model;
 [OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)]
 [OslcResourceShape(title = "OSLC Property Resource Shape",
     describes = new[] { OslcConstants.TYPE_PROPERTY })]
-public sealed class Property : AbstractResource, IComparable<Property>
+public sealed class Property : AbstractResource, IComparable<Property>, IEquatable<Property>
 {
     private readonly IList<string> allowedValues = new List<string>();
     private readonly List<Uri> range = new();
@@ -495,4 +495,6 @@ public sealed class Property : AbstractResource, IComparable<Property>
             this.valueType = ValueType.Unknown;
         }
     }
+
+    public bool Equals(Property other) => CompareTo(other) == 0;
 }

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfInputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfInputFormatter.cs
@@ -48,8 +48,7 @@ public class OslcRdfInputFormatter : TextInputFormatter
             OslcMediaType.TEXT_TURTLE => RdfFormat.Turtle,
             OslcMediaType.APPLICATION_NTRIPLES => RdfFormat.NTriples,
             OslcMediaType.APPLICATION_JSON_LD => RdfFormat.JsonLd,
-            _ => throw new ArgumentOutOfRangeException(nameof(requestedType),
-                "Unknown RDF format"),
+            _ => throw new NotSupportedException($"Unknown RDF format: {requestedType}"),
         };
         using var reader = new StreamReader(context.HttpContext.Request.Body, encoding);
 

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
@@ -61,8 +61,7 @@ public class OslcRdfOutputFormatter : TextOutputFormatter
                 OslcMediaType.TEXT_TURTLE => RdfFormat.Turtle,
                 OslcMediaType.APPLICATION_NTRIPLES => RdfFormat.NTriples,
                 OslcMediaType.APPLICATION_JSON_LD => RdfFormat.JsonLd,
-                _ => throw new ArgumentOutOfRangeException(nameof(requestedType),
-                    "Unknown RDF format"),
+                _ => throw new NotSupportedException($"Unknown RDF format: {requestedType}"),
             },
             Graph = graph
         };


### PR DESCRIPTION
Fixes simple compiler warnings and applies dotnet format formatting rules across the project. Tests remain green.

---
*PR created automatically by Jules for task [4851696327728473096](https://jules.google.com/task/4851696327728473096) started by @berezovskyi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error messages for unsupported RDF formats in input and output processing, providing clearer feedback on format issues.

* **Code Quality**
  * Improved type system compliance for `ParameterInstance` and `Property` classes, enabling better framework integration and comparison semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->