### PR TITLE
Fix straightforward compiler and analyzer warnings across OSLC4Net SDK

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/OslcClient.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/OslcClient.cs
@@ -112,7 +112,7 @@ public class OslcClient : IDisposable
                     "Must be an instance of HttpClientHandler if the certCallback is provided",
                     nameof(userHttpMessageHandler));
             }
-#pragma warning enable MA0039
+#pragma warning restore MA0039
         }
 
         _client = HttpClientFactory.Create(handler);
@@ -134,10 +134,12 @@ public class OslcClient : IDisposable
         };
         if (allowInvalidTlsCerts)
         {
+#pragma warning disable MA0039
             _logger.LogWarning(
                 "TLS certificate validation is compromised! DO NOT USE IN PRODUCTION");
             handler.ServerCertificateCustomValidationCallback =
                 HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+#pragma warning restore MA0039
         }
 
         _formatters = new HashSet<MediaTypeFormatter>();
@@ -177,7 +179,6 @@ public class OslcClient : IDisposable
     {
         return _client;
     }
-
 
     public async Task<OslcResponse<T>> GetResourceAsync<T>(string resourceUri, string? mediaType)
         where T : IExtendedResource, new()
@@ -240,14 +241,13 @@ public class OslcClient : IDisposable
         return GetResourceAsync<T>(resourceUri, null);
     }
 
-
     public Task<OslcResponse<T>> GetResourceAsync<T>(Uri typeURI) where T : IExtendedResource, new()
     {
         return GetResourceAsync<T>(typeURI.ToString(), null);
     }
 
     /// <summary>
-    /// Consider using <see cref="GetResourceAsync{T}"/> instead.
+    /// Consider using <see cref="GetResourceAsync{T}(string, string?)"/> instead.
     /// </summary>
     public async Task<HttpResponseMessage> GetResourceRawAsync(string url, string? mediaType = null)
     {
@@ -710,7 +710,6 @@ public class OslcClient : IDisposable
         QueryCapability? firstQueryCapability = null;
 
         var response = await GetResourceAsync<ServiceProvider>(serviceProviderUrl).ConfigureAwait(false);
-
 
         if (response.StatusCode != HttpStatusCode.OK)
         {

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryParameters.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryParameters.cs
@@ -101,7 +101,7 @@ public class OslcQueryParameters
     {
         try
         {
-            var encodedQueryParms = Uri.EscapeUriString(oslcQueryParam);
+            var encodedQueryParms = Uri.EscapeDataString(oslcQueryParam);
             // NOTE: CLM is picky about encoding and native .NET URL encoder doesn't encode these extra substitutions
             return encodedQueryParms.Replace("#", "%23").Replace("/", "%2F").Replace(":", "%3A")
                 .Replace("=", "%3D");

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
@@ -26,7 +26,7 @@ namespace OSLC4Net.Client.Oslc.Resources;
 [OslcResourceShape(title = "Parameter Instance Resource Shape",
     describes = new string[] { AutomationConstants.TYPE_PARAMETER_INSTANCE })]
 [OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)]
-public class ParameterInstance : AbstractResource
+public class ParameterInstance : AbstractResource, IComparable<ParameterInstance>
 {
 
     private string name;

--- a/OSLC4Net_SDK/OSLC4Net.Client/ServiceProviderRegistryURIs.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/ServiceProviderRegistryURIs.cs
@@ -15,9 +15,9 @@
 
 namespace OSLC4Net.Client;
 
-/// <summary>
-/// This class calculates and store a ServiceProvider Registry URI.
-/// </summary>
+// <summary>
+// This class calculates and store a ServiceProvider Registry URI.
+// </summary>
 // public static class ServiceProviderRegistryURIs
 // {
 //

--- a/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/CompoundTermImpl.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/CompoundTermImpl.cs
@@ -114,7 +114,7 @@ internal class CompoundTermImpl : SimpleTermImpl, CompoundTerm
         return builder.ToString();
     }
 
-    private readonly CommonTree tree;
+    private new readonly CommonTree tree;
     private readonly bool isTopLevel;
     private IList<SimpleTerm> children;
 }

--- a/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/SortTermsImpl.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/SortTermsImpl.cs
@@ -42,15 +42,11 @@ sealed class SortTermsImpl : OrderByClause
                 foreach (var child in rawChildren)
                 {
 
-                    object simpleTerm;
-
                     switch (child.Token.Type)
                     {
                         default:
                             throw new InvalidOperationException("unimplemented type of sort term: " + child.Token.Text);
                     }
-
-                    children.Add((SortTerm)simpleTerm);
                 }
 
                 // XXX - Can't figure out why this doesn't work

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/OccursExtension.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/OccursExtension.cs
@@ -32,7 +32,7 @@ public static class OccursExtension
             }
         }
 
-        throw new ArgumentException();
+        throw new ArgumentException("Value is not a valid Occurs URI", nameof(value));
     }
 
     public static Occurs FromURI(URI uri)

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
@@ -24,7 +24,7 @@ namespace OSLC4Net.Core.Model;
 [OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)]
 [OslcResourceShape(title = "OSLC Property Resource Shape",
     describes = new[] { OslcConstants.TYPE_PROPERTY })]
-public sealed class Property : AbstractResource, IComparable<Property>
+public sealed class Property : AbstractResource, IComparable<Property>, IEquatable<Property>
 {
     private readonly IList<string> allowedValues = new List<string>();
     private readonly List<Uri> range = new();
@@ -192,7 +192,7 @@ public sealed class Property : AbstractResource, IComparable<Property>
             catch (UriFormatException exception)
             {
                 // This should never happen since we control the possible values of the Occurs enum.
-                throw new SystemException(exception.Message, exception);
+                throw new InvalidOperationException(exception.Message, exception);
             }
         }
 
@@ -250,7 +250,7 @@ public sealed class Property : AbstractResource, IComparable<Property>
         catch (UriFormatException exception)
         {
             // This should never happen since we control the possible values of the Representation enum.
-            throw new SystemException(exception.Message, exception);
+            throw new InvalidOperationException(exception.Message, exception);
         }
     }
 
@@ -312,7 +312,7 @@ public sealed class Property : AbstractResource, IComparable<Property>
             catch (UriFormatException exception)
             {
                 // This should never happen since we control the possible values of the ValueType enum.
-                throw new SystemException(exception.Message, exception);
+                throw new InvalidOperationException(exception.Message, exception);
             }
         }
 
@@ -495,4 +495,6 @@ public sealed class Property : AbstractResource, IComparable<Property>
             this.valueType = ValueType.Unknown;
         }
     }
+
+    public bool Equals(Property other) => CompareTo(other) == 0;
 }

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/RepresentationExtension.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/RepresentationExtension.cs
@@ -32,7 +32,7 @@ public static class RepresentationExtension
             }
         }
 
-        throw new ArgumentException();
+        throw new ArgumentException("Value is not a valid Representation URI", nameof(value));
     }
 
     public static Representation FromURI(URI uri)

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/ServiceProviderFactory.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/ServiceProviderFactory.cs
@@ -365,23 +365,19 @@ public class ServiceProviderFactory
         string returnUri;
 
         //Build the path from the @Path template + map of parameter value replacements
+        //Build the path from the @Path template + map of parameter value replacements
+        /* TODO - not supported yet
         if (pathParameterValues != null && pathParameterValues.Count > 0)
         {
-            /* TODO - not supported yet
             UriBuilder builder = UriBuilder.fromUri(basePath);
             URI resolvedUri = builder.path(pathAttribute).buildFromMap(pathParameterValues);
             if (resolvedUri != null)
             {
                 returnUri = resolvedUri.tostring();
             }
+        }
         */
-            returnUri = basePath + "/" + pathAttribute;
-        }
-        else
-        {
-            // no parameters supplied - assume @Path not templated
-            returnUri = basePath + "/" + pathAttribute;
-        }
+        returnUri = basePath + "/" + pathAttribute;
 
         return returnUri;
     }

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfInputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfInputFormatter.cs
@@ -48,8 +48,7 @@ public class OslcRdfInputFormatter : TextInputFormatter
             OslcMediaType.TEXT_TURTLE => RdfFormat.Turtle,
             OslcMediaType.APPLICATION_NTRIPLES => RdfFormat.NTriples,
             OslcMediaType.APPLICATION_JSON_LD => RdfFormat.JsonLd,
-            _ => throw new ArgumentOutOfRangeException(nameof(requestedType),
-                "Unknown RDF format"),
+            _ => throw new NotSupportedException($"Unknown RDF format: {requestedType}"),
         };
         using var reader = new StreamReader(context.HttpContext.Request.Body, encoding);
 

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
@@ -61,8 +61,7 @@ public class OslcRdfOutputFormatter : TextOutputFormatter
                 OslcMediaType.TEXT_TURTLE => RdfFormat.Turtle,
                 OslcMediaType.APPLICATION_NTRIPLES => RdfFormat.NTriples,
                 OslcMediaType.APPLICATION_JSON_LD => RdfFormat.JsonLd,
-                _ => throw new ArgumentOutOfRangeException(nameof(requestedType),
-                    "Unknown RDF format"),
+                _ => throw new NotSupportedException($"Unknown RDF format: {requestedType}"),
             },
             Graph = graph
         };


### PR DESCRIPTION
Eliminated various straightforward compiler warnings across `OSLC4Net_SDK` without introducing new ones, verified behavior via unit tests, and applied `dotnet format` consistency check.

---
*PR created automatically by Jules for task [345614749071175542](https://jules.google.com/task/345614749071175542) started by @berezovskyi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sorting capability for parameter instances.

* **Bug Fixes**
  * Improved error messaging for invalid query parameters and format parsing failures.
  * Enhanced exception handling for unsupported RDF formats with clearer error descriptions.
  * Refined query parameter encoding logic.

* **Documentation**
  * Updated API documentation references for resource retrieval methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->