### PR TITLE
Fix CS1634 warning by correctly restoring MA0039 pragma in OslcClient

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/OslcClient.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/OslcClient.cs
@@ -112,7 +112,7 @@ public class OslcClient : IDisposable
                     "Must be an instance of HttpClientHandler if the certCallback is provided",
                     nameof(userHttpMessageHandler));
             }
-#pragma warning enable MA0039
+#pragma warning restore MA0039
         }
 
         _client = HttpClientFactory.Create(handler);
@@ -136,8 +136,10 @@ public class OslcClient : IDisposable
         {
             _logger.LogWarning(
                 "TLS certificate validation is compromised! DO NOT USE IN PRODUCTION");
+#pragma warning disable MA0039
             handler.ServerCertificateCustomValidationCallback =
                 HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+#pragma warning restore MA0039
         }
 
         _formatters = new HashSet<MediaTypeFormatter>();


### PR DESCRIPTION
Replaces the erroneous `#pragma warning enable MA0039` with `#pragma warning restore MA0039` in `OslcClient.cs` to resolve a CS1634 compiler warning without accidentally exposing new MA0039 warnings from within the class.

---
*PR created automatically by Jules for task [4012777703281945763](https://jules.google.com/task/4012777703281945763) started by @berezovskyi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compiler warning configuration in the OSLC client library. No functional changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->