### PR TITLE
Fix `SortTermsImpl` collection parsing and generation

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/SortTermsImpl.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/SortTermsImpl.cs
@@ -13,8 +13,6 @@
  *     Steve Pitschke  - initial API and implementation
  *******************************************************************************/
 
-using System;
-using System.Collections.Generic;
 using Antlr.Runtime.Tree;
 
 namespace OSLC4Net.Core.Query.Impl;

--- a/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/SortTermsImpl.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.Query/Impl/SortTermsImpl.cs
@@ -13,10 +13,20 @@
  *     Steve Pitschke  - initial API and implementation
  *******************************************************************************/
 
+using System;
+using System.Collections.Generic;
 using Antlr.Runtime.Tree;
 
 namespace OSLC4Net.Core.Query.Impl;
 
+/// <summary>
+/// Implementation of OrderByClause interface that parses and resolves sort terms from an oslc.orderBy query parameter.
+///
+/// It lazily evaluates the Antlr CommonTree representing the terms, generating a read-only list of
+/// <see cref="SortTerm"/> implementations (either <see cref="SimpleSortTermImpl"/> or <see cref="ScopedSortTermImpl"/>).
+/// For example, parsing "+oslc:name,-oslc:shortId,dcterms:creator{+foaf:name}" will yield three sort terms:
+/// two simple terms and one scoped term.
+/// </summary>
 sealed class SortTermsImpl : OrderByClause
 {
     public SortTermsImpl(
@@ -34,27 +44,29 @@ sealed class SortTermsImpl : OrderByClause
         {
             if (children == null)
             {
+                var treeChildren = tree.Children;
+                var list = new List<SortTerm>(treeChildren.Count);
 
-                var rawChildren = (IList<CommonTree>)tree.Children;
-
-                children = new List<SortTerm>(rawChildren.Count);
-
-                foreach (var child in rawChildren)
+                foreach (CommonTree child in treeChildren)
                 {
-
-                    object simpleTerm;
+                    SortTerm term;
 
                     switch (child.Token.Type)
                     {
+                        case OslcOrderByParser.SIMPLE_TERM:
+                            term = new SimpleSortTermImpl(child, prefixMap);
+                            break;
+                        case OslcOrderByParser.SCOPED_TERM:
+                            term = new ScopedSortTermImpl(child, prefixMap);
+                            break;
                         default:
                             throw new InvalidOperationException("unimplemented type of sort term: " + child.Token.Text);
                     }
 
-                    children.Add((SortTerm)simpleTerm);
+                    list.Add(term);
                 }
 
-                // XXX - Can't figure out why this doesn't work
-                // children = children.AsReadOnly();
+                children = list.AsReadOnly();
             }
 
             return children;

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/SortTermsResourceTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/SortTermsResourceTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OSLC4Net.Core.Query;
+using OSLC4Net.Core.Model;
+using OSLC4Net.Core.Attribute;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace OSLC4Net.Core.QueryTests;
+
+[OslcNamespace("http://example.com/ns#")]
+public class MockResource : AbstractResource
+{
+    [OslcName("name")]
+    [OslcPropertyDefinition("http://example.com/ns#name")]
+    public string Name { get; set; }
+
+    [OslcName("id")]
+    [OslcPropertyDefinition("http://example.com/ns#id")]
+    public int Id { get; set; }
+}
+
+public class SortTermsResourceTests
+{
+    [Test]
+    public async Task SortTerms_SortsResources()
+    {
+        var prefixMap = new Dictionary<string, string>
+        {
+            { "ex", "http://example.com/ns#" }
+        };
+
+        var orderByStr = "+ex:id,-ex:name";
+        var orderBy = QueryUtils.ParseOrderBy(orderByStr, prefixMap);
+
+        var resources = new List<MockResource>
+        {
+            new MockResource { Id = 2, Name = "B" },
+            new MockResource { Id = 1, Name = "Z" },
+            new MockResource { Id = 2, Name = "A" },
+        };
+
+        IOrderedEnumerable<MockResource> ordered = null;
+        bool isFirst = true;
+
+        foreach (var term in orderBy.Children)
+        {
+            if (term is SimpleSortTerm simpleTerm)
+            {
+                var identifier = simpleTerm.Identifier.ToString(); // e.g. "http://example.com/ns#id" or "ex:id"?
+
+                Func<MockResource, object> keySelector = null;
+                if (identifier.Contains("id"))
+                {
+                    keySelector = r => r.Id;
+                }
+                else if (identifier.Contains("name"))
+                {
+                    keySelector = r => r.Name;
+                }
+
+                if (keySelector != null)
+                {
+                    if (isFirst)
+                    {
+                        ordered = simpleTerm.Ascending ? resources.OrderBy(keySelector) : resources.OrderByDescending(keySelector);
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        ordered = simpleTerm.Ascending ? ordered.ThenBy(keySelector) : ordered.ThenByDescending(keySelector);
+                    }
+                }
+            }
+        }
+
+        var result = ordered?.ToList();
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result[0].Id).IsEqualTo(1);
+        await Assert.That(result[0].Name).IsEqualTo("Z");
+
+        // id 2, desc name: "B" > "A"
+        await Assert.That(result[1].Id).IsEqualTo(2);
+        await Assert.That(result[1].Name).IsEqualTo("B");
+
+        await Assert.That(result[2].Id).IsEqualTo(2);
+        await Assert.That(result[2].Name).IsEqualTo("A");
+    }
+}

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/SortTermsResourceTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/SortTermsResourceTests.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using OSLC4Net.Core.Query;
-using OSLC4Net.Core.Model;
 using OSLC4Net.Core.Attribute;
+using OSLC4Net.Core.Model;
+using OSLC4Net.Core.Query;
 using TUnit.Assertions;
 using TUnit.Assertions.Extensions;
 

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/SortTermsTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.QueryTests/SortTermsTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OSLC4Net.Core.Query;
+using TUnit.Assertions;
+using TUnit.Assertions.Extensions;
+
+namespace OSLC4Net.Core.QueryTests;
+
+public class SortTermsTests
+{
+    [Test]
+    public async Task ParseOrderBy_ReturnsValidSortTermsImpl()
+    {
+        var prefixMap = new Dictionary<string, string>
+        {
+            { "oslc", "http://open-services.net/ns/core#" },
+            { "dcterms", "http://purl.org/dc/terms/" },
+            { "foaf", "http://xmlns.com/foaf/0.1/" }
+        };
+        var orderByStr = "+oslc:name,-oslc:shortId,dcterms:creator{+foaf:name}";
+        var sortTerms = QueryUtils.ParseOrderBy(orderByStr, prefixMap);
+
+        var children = sortTerms.Children;
+        await Assert.That(children).IsNotNull();
+        await Assert.That(children.Count).IsEqualTo(3);
+
+        // Ensure it's read only!
+        await Assert.That(() => children.Add(null)).Throws<NotSupportedException>();
+    }
+}


### PR DESCRIPTION
Fixes an issue where `SortTermsImpl` fails to correctly parse inner elements mapped from `OslcOrderByParser`. It previously attempted to call `AsReadOnly()` directly on an `IList` variable, producing an exception. Replaces empty switch statements with term instantiation logic. Included a new TUnit test mapping terms evaluation.

---
*PR created automatically by Jules for task [2993148301810737737](https://jules.google.com/task/2993148301810737737) started by @berezovskyi*