### PR TITLE
Fix CA2208 warnings across the project

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/OccursExtension.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/OccursExtension.cs
@@ -32,7 +32,7 @@ public static class OccursExtension
             }
         }
 
-        throw new ArgumentException();
+        throw new ArgumentException($"Invalid string representation of Occurs value: {value}", nameof(value));
     }
 
     public static Occurs FromURI(URI uri)

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/RepresentationExtension.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/RepresentationExtension.cs
@@ -32,7 +32,7 @@ public static class RepresentationExtension
             }
         }
 
-        throw new ArgumentException();
+        throw new ArgumentException($"Invalid string representation of Representation value: {value}", nameof(value));
     }
 
     public static Representation FromURI(URI uri)

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfInputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfInputFormatter.cs
@@ -48,8 +48,7 @@ public class OslcRdfInputFormatter : TextInputFormatter
             OslcMediaType.TEXT_TURTLE => RdfFormat.Turtle,
             OslcMediaType.APPLICATION_NTRIPLES => RdfFormat.NTriples,
             OslcMediaType.APPLICATION_JSON_LD => RdfFormat.JsonLd,
-            _ => throw new ArgumentOutOfRangeException(nameof(requestedType),
-                "Unknown RDF format"),
+            _ => throw new NotSupportedException($"Unknown RDF format: {requestedType}"),
         };
         using var reader = new StreamReader(context.HttpContext.Request.Body, encoding);
 

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
@@ -61,8 +61,7 @@ public class OslcRdfOutputFormatter : TextOutputFormatter
                 OslcMediaType.TEXT_TURTLE => RdfFormat.Turtle,
                 OslcMediaType.APPLICATION_NTRIPLES => RdfFormat.NTriples,
                 OslcMediaType.APPLICATION_JSON_LD => RdfFormat.JsonLd,
-                _ => throw new ArgumentOutOfRangeException(nameof(requestedType),
-                    "Unknown RDF format"),
+                _ => throw new NotSupportedException($"Unknown RDF format: {requestedType}"),
             },
             Graph = graph
         };


### PR DESCRIPTION
Fixes CA2208 warnings across the OSLC4Net_SDK project related to improper instantiation of ArgumentExceptions.

---
*PR created automatically by Jules for task [9180717376505650744](https://jules.google.com/task/9180717376505650744) started by @berezovskyi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for invalid enum value conversions now include context about the problematic input parameter.
  * Unsupported RDF content types now throw more appropriate exceptions with the full content-type string included in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->