### PR TITLE
docs(agents): document the copyright-header policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,31 @@ dotnet format whitespace ./OSLC4Net_SDK && dotnet format style ./OSLC4Net_SDK --
 - Also run this **after resolving merge conflicts**. Hand-edited hunks re-introduce style drift even when both parents were clean.
 - A pre-commit hook (`.pre-commit-config.yaml`) enforces this; install once with `pre-commit install`.
 
+## Copyright headers
+
+Any file you've **significantly** touched (substantive code, docs, or
+non-trivial test changes — not just whitespace, renames, or a one-line
+tweak) should carry the line:
+
+```
+Copyright (c) <YYYY> Andrii Berezovskyi and OSLC4Net contributors.
+```
+
+where `<YYYY>` is the current year **at the time you add the line**.
+
+Rules:
+- **New files**: include this line as the sole copyright attribution (no
+  inherited IBM/contributor headers).
+- **Existing files** that already have other copyright attributions
+  (e.g. `Copyright (c) 2012 IBM Corporation.`): add the
+  `Andrii Berezovskyi and OSLC4Net contributors.` line immediately after
+  the last existing copyright line. Preserve all other attributions and
+  the `Contributors:` block.
+- **Existing files** that already carry an
+  `Andrii Berezovskyi and OSLC4Net contributors.` line: leave the year
+  alone. Do not "refresh" it to the current year.
+- Never remove other copyright attributions.
+
 ## Project Structure
 
 - `OSLC4Net_SDK/` - Main SDK projects (.NET 10)


### PR DESCRIPTION
## Summary

Adds a *Copyright headers* section to `AGENTS.md` so future contributors (human or agent) know when and how to attach the standard attribution line:

> `Copyright (c) <YYYY> Andrii Berezovskyi and OSLC4Net contributors.`

The rules captured in writing:
- **New files** — line is the sole attribution.
- **Existing files with other attributions** (e.g. the IBM Corporation header) — append after the last existing copyright line; never replace.
- **Existing files already carrying the line** — leave the year alone; don't "refresh" it.
- Never remove other copyright attributions.

No code changes. Follow-up PRs will retroactively apply the line to files significantly touched in the currently open PRs (e.g. #363 and #491).

## Test plan

- [ ] Reviewer reads the new section in `AGENTS.md` and confirms the rules match the intended policy
- [ ] Open the file via the `CLAUDE.md` symlink and confirm the section renders the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor documentation with new copyright header guidelines providing clear guidance on how to properly insert copyright attributions in significantly modified files, including standards for attribution text formatting, year handling conventions, and detailed procedures for adding new contributor information alongside existing copyright notices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OSLC/oslc4net/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->