### PR TITLE
Fix MA0015 by using appropriate exception types

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryResult.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryResult.cs
@@ -399,7 +399,7 @@ public class OslcQueryResult : IEnumerator<OslcQueryResult>
                 get
                 {
                     var member = _triples.Current ??
-                                 throw new ArgumentNullException(nameof(_triples.Current));
+                                 throw new InvalidOperationException("Current element is null");
                     return (T)_dotNetRdfHelper.FromDotNetRdfNode((IUriNode)member.Object, _graph,
                         typeof(T));
                 }

--- a/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/DotNetRdfHelper.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/DotNetRdfHelper.cs
@@ -604,7 +604,7 @@ public class DotNetRdfHelper(ILogger<DotNetRdfHelper> logger)
                                 }
                                 else
                                 {
-                                    throw new ArgumentException("'" + stringValue +
+                                    throw new FormatException("'" + stringValue +
                                                                 "' has wrong format for Boolean.");
                                 }
                             }


### PR DESCRIPTION
Fix MA0015 by using appropriate exception types

Corrected incorrect usage of `ArgumentException` and `ArgumentNullException` to use the semantically correct `FormatException` and `InvalidOperationException` respectively. This naturally resolves the MA0015 warnings without creating artificial parameter name arguments.

---
*PR created automatically by Jules for task [7839445313587337513](https://jules.google.com/task/7839445313587337513) started by @berezovskyi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting when retrieving query results with null values and when parsing invalid boolean literals with more specific exception types for clearer troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OSLC/oslc4net/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->