### PR TITLE
ci: upload coverage to GitHub PR code coverage (preview)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
     permissions:
       contents: read  # for actions/checkout to fetch code
       packages: write  # for setup-dotnet to create package
+      code-quality: write  # for actions/upload-code-coverage
     strategy:
       fail-fast: false
       matrix:
@@ -188,6 +189,15 @@ jobs:
           exclude: .nuget,main/OSLC4Net_SDK/Examples
           # files: "${{ github.workspace }}/main/OSLC4Net_SDK/Tests/*/TestResults/*.coverage,${{ github.workspace }}/main/OSLC4Net_SDK/Tests/*/TestResults/*.xml"
           files: ${{ github.workspace }}/coveragereports/Cobertura.xml
+      - name: Upload coverage report to GitHub
+        # Upload from a single matrix leg to avoid duplicate reports for the same SHA.
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+        with:
+          file: ${{ github.workspace }}/coveragereports/Cobertura.xml
+          language: 'C#'
+          label: 'dotnet/cobertura'
+          fail-on-error: false
       - name: Pack NuGet packages (snapshot)
         shell: pwsh
         run: |


### PR DESCRIPTION
## Summary

- Wires up [GitHub's new PR code coverage feature](https://github.blog/changelog/2026-05-26-code-coverage-in-pull-requests-is-now-in-public-preview/) (public preview, May 2026) using [`actions/upload-code-coverage`](https://github.com/actions/upload-code-coverage).
- The test job already produces a merged `Cobertura.xml` via ReportGenerator, so the upload reuses that artifact — no extra build cost.
- Grants `code-quality: write` to the `test` job (required by the action) and pins the action to `v1.3.0` (SHA), matching the repo's pinning convention.
- Upload runs only on the `ubuntu-24.04` matrix leg so the three OS runs don't push duplicate reports for the same SHA.
- `fail-on-error: false` so a transient API hiccup, or the feature not being enabled at the repo level during the preview, won't fail CI.

Codecov upload is left untouched.

## Test plan

- [ ] CI is green on this PR.
- [ ] Once merged (or on this PR if the feature is already enabled), confirm the coverage indicator shows up in the PR's Files Changed view.
- [ ] If the feature isn't enabled yet at the repo level, enable it in repo settings (Code security / Code coverage) — the workflow will start reporting automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow with improved code coverage upload capabilities on Ubuntu environments.
  * Updated test job permissions to support package-related operations during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->