### PR TITLE
Fix CA2201: Use InvalidOperationException instead of SystemException

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ dotnet reportgenerator -reports:"**/coverage.cobertura.xml" -targetdir:"./Covera
 
 ## Docs
 
-- If a change is significant, add a line to CHANGELOG.md
+- Every breaking change must have at least a one-liner in the CHANGELOG.md. If a change is significant, add a line as well.
 - If a change breaks anything or requires a non-trivial migration step, add a section to MIGRATION.md
 - If a change is noteworthy, add docs to the `docs/articles`. Use snippets where possible. Strive to apply https://diataxis.fr/. Prefer spelling out type names over 'var' except for literals and obvious types. Skip ceremony like setting up loggers or ConfigureAwait. Refrain from numbering sections/subsections to make it easier to restructure content.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release does not remove any features.
 
 - Properties backed by URI collections are now reflected in OSLC shapes correctly (thanks to @ZUOXIANGE)
 - `OslcQueryResult` now handles cases where RDF graph parsing from query responses produces malformed URI nodes. Instead of throwing `ArgumentNullException`, methods like `GetMembersUrls()`, `GetMembers<T>()`, `GetNextPageUrl()`, and `GetTotalCount()` now gracefully return empty results or null values.
+- Replaced the use of `SystemException` with `InvalidOperationException` in `Property.cs` to resolve compiler warning CA2201.
 
 
 ## [0.6.3] - 2025-11-15

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
@@ -192,7 +192,7 @@ public sealed class Property : AbstractResource, IComparable<Property>
             catch (UriFormatException exception)
             {
                 // This should never happen since we control the possible values of the Occurs enum.
-                throw new SystemException(exception.Message, exception);
+                throw new InvalidOperationException(exception.Message, exception);
             }
         }
 
@@ -250,7 +250,7 @@ public sealed class Property : AbstractResource, IComparable<Property>
         catch (UriFormatException exception)
         {
             // This should never happen since we control the possible values of the Representation enum.
-            throw new SystemException(exception.Message, exception);
+            throw new InvalidOperationException(exception.Message, exception);
         }
     }
 
@@ -312,7 +312,7 @@ public sealed class Property : AbstractResource, IComparable<Property>
             catch (UriFormatException exception)
             {
                 // This should never happen since we control the possible values of the ValueType enum.
-                throw new SystemException(exception.Message, exception);
+                throw new InvalidOperationException(exception.Message, exception);
             }
         }
 


### PR DESCRIPTION
This PR addresses the compiler warning CA2201 by replacing `SystemException` with `InvalidOperationException` in `Property.cs`. The exceptions are thrown in scenarios that "should never happen" involving internally defined enums, making `InvalidOperationException` a more appropriate and specific exception type than the reserved `SystemException`.

---
*PR created automatically by Jules for task [6536641209769058512](https://jules.google.com/task/6536641209769058512) started by @berezovskyi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling so enum-to-URI conversion failures now throw a more appropriate exception type without changing visible behavior.

* **Documentation**
  * Updated contribution guidance to require explicit changelog entries for breaking or significant changes and added a changelog note describing the exception-type fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->