### PR TITLE
client: support post queries and declared result members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This release does not contain security updates.
 
 ### Added
 
+- `OslcQuery.SubmitPost()` submits form-encoded OSLC queries over HTTP POST.
 - `RootServicesHelper` was added to assist with processing OSLC Root Services documents. It can help with direct lookups (as long as your URI ends with `/rootservices` or `/rootservices.xml`), can look up a standard `/.well-known/oslc/rootservices.xml` location, or fall back to appending `/rootservices` for legacy systems.
 - ⚡️Samples for IBM Jazz ERM (aka Doors NG), ETM, and EWM were migrated to .NET 10 and tested against Jazz.net. You can run them yourself using `OSLC4Net_SDK\Examples\scripts\test-jazz_net.ps1`.
 
@@ -38,6 +39,7 @@ This release does not remove any features.
 
 ### Fixed
 
+- Query results recognize membership predicates declared through `ldp:hasMemberRelation` or explicitly supplied to `OslcQuery`, and support `ldp:contains` query containers.
 - Properties backed by URI collections are now reflected in OSLC shapes correctly (thanks to @ZUOXIANGE)
 - `OslcQueryResult` now handles cases where RDF graph parsing from query responses produces malformed URI nodes. Instead of throwing `ArgumentNullException`, methods like `GetMembersUrls()`, `GetMembers<T>()`, `GetNextPageUrl()`, and `GetTotalCount()` now gracefully return empty results or null values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This release does not remove any features.
 ### Fixed
 
 - Query results recognize membership predicates declared through `ldp:hasMemberRelation` or explicitly supplied to `OslcQuery`, and support `ldp:contains` query containers.
+- Query result total counts are parsed from RDF literal nodes.
 - Properties backed by URI collections are now reflected in OSLC shapes correctly (thanks to @ZUOXIANGE)
 - `OslcQueryResult` now handles cases where RDF graph parsing from query responses produces malformed URI nodes. Instead of throwing `ArgumentNullException`, methods like `GetMembersUrls()`, `GetMembers<T>()`, `GetNextPageUrl()`, and `GetTotalCount()` now gracefully return empty results or null values.
 

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQuery.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQuery.cs
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2013 IBM Corporation.
+ * Copyright (c) 2026 Andrii Berezovskyi and OSLC4Net contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,12 +15,14 @@
  *******************************************************************************/
 
 using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text;
 using OSLC4Net.Core.DotNetRdfProvider;
 
 namespace OSLC4Net.Client.Oslc.Resources;
 
 /// <summary>
-///     Represents an OSLC query (HTTP GET) request to be made of a remote system.
+///     Represents an OSLC query request to be made of a remote system.
 ///     Immutable.
 /// </summary>
 public class OslcQuery
@@ -28,6 +31,7 @@ public class OslcQuery
     private readonly string capabilityUrl;
     private readonly string orderBy;
     private readonly OslcClient oslcClient;
+    private readonly Uri? memberRelation;
 
     private readonly int pageSize;
     private readonly string prefix;
@@ -110,6 +114,30 @@ public class OslcQuery
         queryUrl = GetQueryUrl();
     }
 
+    /// <summary>
+    ///     Create an OSLC query with an explicitly declared query-result membership relation.
+    /// </summary>
+    /// <param name="oslcClient">the authenticated OSLC client</param>
+    /// <param name="capabilityUrl">the URL that is the query base</param>
+    /// <param name="pageSize">the number of results to include on each page</param>
+    /// <param name="oslcQueryParams">an <see cref="OslcQueryParameters" /> object</param>
+    /// <param name="memberRelation">
+    ///     the RDF property that relates the query result container to each result member
+    /// </param>
+    public OslcQuery(OslcClient oslcClient, string capabilityUrl,
+        int pageSize, OslcQueryParameters oslcQueryParams, Uri memberRelation) :
+        this(oslcClient, capabilityUrl, pageSize, oslcQueryParams)
+    {
+        ArgumentNullException.ThrowIfNull(memberRelation);
+        if (!memberRelation.IsAbsoluteUri)
+        {
+            throw new ArgumentException("The member relation must be an absolute URI.",
+                nameof(memberRelation));
+        }
+
+        this.memberRelation = memberRelation;
+    }
+
     internal OslcQuery(OslcQueryResult previousResult) :
         this(previousResult.GetQuery(), previousResult.GetNextPageUrl())
     {
@@ -118,6 +146,7 @@ public class OslcQuery
     private OslcQuery(OslcQuery previousQuery, string nextPageUrl) :
         this(previousQuery.oslcClient, previousQuery.capabilityUrl, previousQuery.pageSize)
     {
+        memberRelation = previousQuery.memberRelation;
         queryUrl = nextPageUrl;
         uriBuilder = new UriBuilder(nextPageUrl);
     }
@@ -129,6 +158,8 @@ public class OslcQuery
     ///     results will have the same subject URI.
     /// </summary>
     public Uri QueryUri => uriBuilder.Uri;
+
+    internal Uri? MemberRelation => memberRelation;
 
     private void ApplyPagination()
     {
@@ -199,9 +230,31 @@ public class OslcQuery
             _rdfHelper);
     }
 
+    /// <summary>
+    ///     Submits the query as an HTTP POST whose body uses
+    ///     <c>application/x-www-form-urlencoded</c>, as defined by OSLC Query 3.0.
+    /// </summary>
+    public async Task<OslcQueryResult> SubmitPost()
+    {
+        return new OslcQueryResult(this, await GetPostResponseRawAsync().ConfigureAwait(false),
+            _rdfHelper);
+    }
+
     internal Task<HttpResponseMessage> GetResponseRawAsync()
     {
         return oslcClient.GetResourceRawAsync(QueryUri.ToString(), OSLCConstants.CT_RDF);
+    }
+
+    internal async Task<HttpResponseMessage> GetPostResponseRawAsync()
+    {
+        var query = QueryUri.Query.TrimStart('?');
+        using var request = new HttpRequestMessage(HttpMethod.Post, CapabilityUrl);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(OSLCConstants.CT_RDF));
+        request.Headers.TryAddWithoutValidation(OSLCConstants.OSLC_CORE_VERSION, "2.0");
+        request.Content = new ByteArrayContent(Encoding.UTF8.GetBytes(query));
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue(
+            "application/x-www-form-urlencoded");
+        return await oslcClient.GetHttpClient().SendAsync(request).ConfigureAwait(false);
     }
 
     private void QueryParam(string name, string value)

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryResult.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryResult.cs
@@ -34,6 +34,12 @@ namespace OSLC4Net.Client.Oslc.Resources;
 public class OslcQueryResult : IEnumerator<OslcQueryResult>
 {
     private static readonly Uri _rdfsMemberUri = new("http://www.w3.org/2000/01/rdf-schema#member");
+    private static readonly Uri _ldpContainsUri = new(
+        global::OSLC4Net.Core.Model.OslcConstants.Domains.LDP.P.Contains);
+    private static readonly Uri _ldpHasMemberRelationUri = new(
+        global::OSLC4Net.Core.Model.OslcConstants.Domains.LDP.P.HasMemberRelation);
+    private static readonly Uri _ldpMembershipResourceUri = new(
+        global::OSLC4Net.Core.Model.OslcConstants.Domains.LDP.P.MembershipResource);
 
     private static readonly Uri _responsePredicateUri = new(OslcConstants.OSLC_CORE_NAMESPACE +
                                                             "ResponseInfo");
@@ -55,6 +61,8 @@ public class OslcQueryResult : IEnumerator<OslcQueryResult>
     private bool _rdfInitialized;
 
     private IUriNode? _rdfType;
+    private IUriNode? _memberRelation;
+    private IUriNode? _membershipResource;
     private IUriNode? _resultsMemberContainer;
 
     private long? _totalCount;
@@ -184,13 +192,18 @@ public class OslcQueryResult : IEnumerator<OslcQueryResult>
             _infoResource ??= GetInfoResourceExactCapabilityMatch(_rdfGraph);
             _infoResource ??= GetInfoResourceSubjectStartsWithCapabilityUri(triples);
 
-            // Use the same resource for members container, with same fallback chain
+            // OSLC Query requires the result container subject to be the query base URI.
+            _resultsMemberContainer ??= GetExactCapabilityResource(_rdfGraph);
+
+            // Retain the legacy fallback chain for non-conforming OSLC 2.0 responses.
             _resultsMemberContainer ??= GetInfoResourceExactCapabilityMatch(_rdfGraph);
             _resultsMemberContainer ??= GetSingleInfoResource(triples);
             _resultsMemberContainer ??= GetInfoResourceExactQueryMatch(triples);
             _resultsMemberContainer ??= GetInfoResourceSubjectStartsWithQueryUri(triples);
             _resultsMemberContainer ??= GetInfoResourceSubjectStartsWithCapabilityUri(triples);
             _resultsMemberContainer ??= _infoResource;
+
+            ResolveMembershipRelation();
         }
     }
 
@@ -217,6 +230,55 @@ public class OslcQueryResult : IEnumerator<OslcQueryResult>
         return triples?.FirstOrDefault(spo =>
             spo.Subject is IUriNode node &&
             node.Uri.Equals(new Uri(_query.CapabilityUrl)))?.Subject as IUriNode;
+    }
+
+    private IUriNode? GetExactCapabilityResource(IGraph graph)
+    {
+        var subject = graph.CreateUriNode(new Uri(_query.CapabilityUrl));
+        return graph.GetTriplesWithSubject(subject).Any()
+            ? subject
+            : null;
+    }
+
+    private void ResolveMembershipRelation()
+    {
+        if (_rdfGraph is null || _resultsMemberContainer is null)
+        {
+            return;
+        }
+
+        _membershipResource = GetUriObject(
+            _resultsMemberContainer,
+            _ldpMembershipResourceUri) ?? _resultsMemberContainer;
+
+        // A DirectContainer declaration describes the actual response representation and wins
+        // over a client-supplied relation discovered from the query capability's resource shape.
+        _memberRelation = GetUriObject(_resultsMemberContainer, _ldpHasMemberRelationUri);
+        _memberRelation ??= _query.MemberRelation is null
+            ? null
+            : _rdfGraph.CreateUriNode(_query.MemberRelation);
+        _memberRelation ??= HasUriMembers(_membershipResource, _rdfsMemberUri)
+            ? _rdfGraph.CreateUriNode(_rdfsMemberUri)
+            : null;
+        _memberRelation ??= HasUriMembers(_membershipResource, _ldpContainsUri)
+            ? _rdfGraph.CreateUriNode(_ldpContainsUri)
+            : null;
+    }
+
+    private IUriNode? GetUriObject(IUriNode subject, Uri predicate)
+    {
+        return _rdfGraph!
+            .GetTriplesWithSubjectPredicate(subject, _rdfGraph.CreateUriNode(predicate))
+            .Select(triple => triple.Object)
+            .OfType<IUriNode>()
+            .FirstOrDefault();
+    }
+
+    private bool HasUriMembers(IUriNode subject, Uri predicate)
+    {
+        return _rdfGraph!
+            .GetTriplesWithSubjectPredicate(subject, _rdfGraph.CreateUriNode(predicate))
+            .Any(triple => triple.Object is IUriNode);
     }
 
     private IUriNode? GetInfoResourceSubjectStartsWithQueryUri(Triple[]? triples)
@@ -304,16 +366,8 @@ public class OslcQueryResult : IEnumerator<OslcQueryResult>
             return membersUrls.ToArray();
         }
 
-        var triples = _rdfGraph!.GetTriplesWithSubject(_resultsMemberContainer);
-
-        foreach (var triple in triples)
+        foreach (var triple in GetMemberTriples())
         {
-            if (!triple.Predicate.Equals(
-                    _rdfGraph.GetUriNode(_rdfsMemberUri)))
-            {
-                continue;
-            }
-
             if (triple.Object is IUriNode uriNode)
             {
                 membersUrls.Add(uriNode.Uri.ToString());
@@ -339,16 +393,23 @@ public class OslcQueryResult : IEnumerator<OslcQueryResult>
             return Enumerable.Empty<T>();
         }
 
-        var triples = _rdfGraph!.GetTriplesWithSubject(_resultsMemberContainer);
-
-        // Filter to only rdfs:member predicates with URI objects (same logic as GetMembersUrls)
-        var memberTriples = triples.Where(triple =>
-            triple.Predicate.Equals(_rdfGraph.GetUriNode(_rdfsMemberUri)) &&
-            triple.Object is IUriNode);
+        var memberTriples = GetMemberTriples();
 
         IEnumerable<T> result = new TripleEnumerableWrapper<T>(memberTriples, _rdfGraph, _rdfHelper);
 
         return result;
+    }
+
+    private IEnumerable<Triple> GetMemberTriples()
+    {
+        if (_membershipResource is null || _memberRelation is null)
+        {
+            return Enumerable.Empty<Triple>();
+        }
+
+        return _rdfGraph!
+            .GetTriplesWithSubjectPredicate(_membershipResource, _memberRelation)
+            .Where(triple => triple.Object is IUriNode);
     }
 
     private sealed class TripleEnumerableWrapper<T> : IEnumerable<T>

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryResult.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/OslcQueryResult.cs
@@ -21,7 +21,6 @@ using System.Runtime.CompilerServices;
 using OSLC4Net.Core.DotNetRdfProvider;
 using OSLC4Net.Core.Model;
 using VDS.RDF;
-using VDS.RDF.Nodes;
 using VDS.RDF.Parsing;
 
 namespace OSLC4Net.Client.Oslc.Resources;
@@ -149,14 +148,14 @@ public class OslcQueryResult : IEnumerator<OslcQueryResult>
         var predicateNode = _rdfGraph.CreateUriNode(_totalCountPredicateUri);
         var totalCountObject = _rdfGraph
             .GetTriplesWithSubjectPredicate(_infoResource, predicateNode)
-            .SingleOrDefault()?.Object as IValuedNode;
+            .SingleOrDefault()?.Object as ILiteralNode;
 
         if (totalCountObject is null)
         {
             return null;
         }
 
-        var countString = totalCountObject.AsString();
+        var countString = totalCountObject.Value;
         return long.TryParse(countString, NumberStyles.Integer, CultureInfo.InvariantCulture, out var totalCount) ? totalCount : null;
     }
 

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Client.Tests/OslcQueryResultTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Client.Tests/OslcQueryResultTests.cs
@@ -181,6 +181,40 @@ public class OslcQueryResultTests
     }
 
     [Test]
+    public async Task ResponseInfoReturnsMembersAndLiteralTotalCount()
+    {
+        const string capabilityUrl =
+            "https://example.test/oslc/workitems/query/release";
+        const string memberUrl =
+            "https://example.test/oslc/workitems/REL-1";
+        var responseText = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rdf:RDF
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+                xmlns:oslc="http://open-services.net/ns/core#"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+              <oslc:ResponseInfo rdf:about="https://example.test/oslc/workitems/query/release">
+                <rdfs:member rdf:resource="https://example.test/oslc/workitems/REL-1" />
+                <oslc:totalCount rdf:datatype="http://www.w3.org/2001/XMLSchema#int">1</oslc:totalCount>
+              </oslc:ResponseInfo>
+            </rdf:RDF>
+            """;
+        var testQuery = new OslcQuery(
+            new OslcClient(LoggerFactory.CreateLogger<OslcClient>()),
+            capabilityUrl);
+        var response = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseText)
+        };
+        var result = new OslcQueryResult(testQuery, response);
+
+        await Assert.That(result.GetMembersUrls()).IsEquivalentTo([memberUrl]);
+        await Assert.That(result.TotalCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task UndeclaredDomainPredicateIsNotGuessed()
     {
         const string capabilityUrl = "https://example.test/qm/testcases";

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Client.Tests/OslcQueryResultTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Client.Tests/OslcQueryResultTests.cs
@@ -15,6 +15,7 @@ using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OSLC4Net.Core.Model;
 
 namespace OSLC4Net.Client.Oslc.Resources;
 
@@ -63,6 +64,148 @@ public class OslcQueryResultTests
         Console.WriteLine($"Total: {oslcQueryResult.TotalCount}");
 
         await Assert.That(oslcQueryResult.GetMembersUrls().Length).IsEqualTo(20);
+    }
+
+    [Test]
+    public async Task ExplicitMembershipPredicateIsRecognizedWithoutGuessing()
+    {
+        const string capabilityUrl = "https://example.test/qm/testcases";
+        const string memberUrl = "https://example.test/qm/testcases/1";
+        var responseText = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rdf:RDF
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:oslc="http://open-services.net/ns/core#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:oslc_qm="http://open-services.net/ns/qm#">
+              <rdf:Description rdf:about="https://example.test/qm/testcases?oslc.where=true">
+                <rdf:type rdf:resource="http://open-services.net/ns/core#ResponseInfo" />
+                <oslc:totalCount>1</oslc:totalCount>
+              </rdf:Description>
+              <rdf:Description rdf:about="https://example.test/qm/testcases">
+                <rdf:type rdf:resource="http://open-services.net/ns/qm#TestCaseQuery" />
+                <foaf:maker rdf:resource="https://example.test/users/not-a-member" />
+                <oslc_qm:testCase rdf:resource="https://example.test/qm/testcases/1" />
+              </rdf:Description>
+              <rdf:Description rdf:about="https://example.test/qm/testcases/1">
+                <rdf:type rdf:resource="http://open-services.net/ns/qm#TestCase" />
+                <dcterms:title>Flight test</dcterms:title>
+              </rdf:Description>
+            </rdf:RDF>
+            """;
+        var testQuery = new OslcQuery(
+            new OslcClient(LoggerFactory.CreateLogger<OslcClient>()),
+            capabilityUrl,
+            0,
+            new OslcQueryParameters(),
+            new Uri(OSLCConstants.QM_TEST_CASE));
+        var response = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseText)
+        };
+        var result = new OslcQueryResult(testQuery, response);
+
+        await Assert.That(result.GetMembersUrls()).IsEquivalentTo([memberUrl]);
+        var member = result.GetMembers<AnyResource>().Single();
+        await Assert.That(member.GetExtendedProperties().Keys.Any(key =>
+            key.NamespaceUri == "http://purl.org/dc/terms/" && key.LocalPart == "title")).IsTrue();
+    }
+
+    [Test]
+    public async Task LdpHasMemberRelationAndMembershipResourceAreRecognized()
+    {
+        const string capabilityUrl = "https://example.test/qm/testcases";
+        const string memberUrl = "https://example.test/qm/testcases/1";
+        var responseText = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rdf:RDF
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:ldp="http://www.w3.org/ns/ldp#"
+                xmlns:oslc_qm="http://open-services.net/ns/qm#">
+              <rdf:Description rdf:about="https://example.test/qm/testcases">
+                <rdf:type rdf:resource="http://www.w3.org/ns/ldp#DirectContainer" />
+                <ldp:membershipResource rdf:resource="https://example.test/qm/testcase-members" />
+                <ldp:hasMemberRelation rdf:resource="http://open-services.net/ns/qm#testCase" />
+                <ldp:contains rdf:resource="https://example.test/qm/not-a-query-result" />
+              </rdf:Description>
+              <rdf:Description rdf:about="https://example.test/qm/testcase-members">
+                <oslc_qm:testCase rdf:resource="https://example.test/qm/testcases/1" />
+              </rdf:Description>
+            </rdf:RDF>
+            """;
+        var testQuery = new OslcQuery(
+            new OslcClient(LoggerFactory.CreateLogger<OslcClient>()),
+            capabilityUrl,
+            0,
+            new OslcQueryParameters(),
+            new Uri("http://xmlns.com/foaf/0.1/maker"));
+        var response = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseText)
+        };
+        var result = new OslcQueryResult(testQuery, response);
+
+        await Assert.That(result.GetMembersUrls()).IsEquivalentTo([memberUrl]);
+    }
+
+    [Test]
+    public async Task LdpContainsIsRecognizedAsAStandardMembershipPredicate()
+    {
+        const string capabilityUrl = "https://example.test/qm/testcases";
+        const string memberUrl = "https://example.test/qm/testcases/1";
+        var responseText = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rdf:RDF
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:ldp="http://www.w3.org/ns/ldp#">
+              <rdf:Description rdf:about="https://example.test/qm/testcases">
+                <rdf:type rdf:resource="http://www.w3.org/ns/ldp#BasicContainer" />
+                <ldp:contains rdf:resource="https://example.test/qm/testcases/1" />
+              </rdf:Description>
+            </rdf:RDF>
+            """;
+        var testQuery = new OslcQuery(
+            new OslcClient(LoggerFactory.CreateLogger<OslcClient>()),
+            capabilityUrl);
+        var response = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseText)
+        };
+        var result = new OslcQueryResult(testQuery, response);
+
+        await Assert.That(result.GetMembersUrls()).IsEquivalentTo([memberUrl]);
+    }
+
+    [Test]
+    public async Task UndeclaredDomainPredicateIsNotGuessed()
+    {
+        const string capabilityUrl = "https://example.test/qm/testcases";
+        var responseText = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rdf:RDF
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:oslc_qm="http://open-services.net/ns/qm#">
+              <rdf:Description rdf:about="https://example.test/qm/testcases">
+                <rdf:type rdf:resource="http://open-services.net/ns/qm#TestCaseQuery" />
+                <oslc_qm:testCase rdf:resource="https://example.test/qm/testcases/1" />
+              </rdf:Description>
+            </rdf:RDF>
+            """;
+        var testQuery = new OslcQuery(
+            new OslcClient(LoggerFactory.CreateLogger<OslcClient>()),
+            capabilityUrl);
+        var response = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(responseText)
+        };
+        var result = new OslcQueryResult(testQuery, response);
+
+        await Assert.That(result.GetMembersUrls()).IsEmpty();
     }
 
     private async Task<OslcQueryResult> GetMockOslcQueryResultMulti()

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Client.Tests/OslcQueryTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Client.Tests/OslcQueryTests.cs
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Andrii Berezovskyi and OSLC4Net contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ *******************************************************************************/
+
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace OSLC4Net.Client.Oslc.Resources;
+
+public class OslcQueryTests
+{
+    [Test]
+    public async Task MemberRelationMustBeAnAbsoluteUri()
+    {
+        using var client = new OslcClient(
+            new HttpClient(),
+            NullLogger<OslcClient>.Instance);
+
+        await Assert.That(() =>
+            _ = new OslcQuery(
+                client,
+                "https://example.test/oslc/query",
+                0,
+                new OslcQueryParameters(),
+                new Uri("relative", UriKind.Relative)))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task SubmitPostUsesFormEncodedBodyWithoutDoubleEncoding()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        string? capturedBody = null;
+        var handler = new OSLC4Net.Client.Tests.FakeHttpMessageHandler(async (request, _) =>
+        {
+            capturedRequest = request;
+            capturedBody = await request.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" />
+                    """)
+            };
+        });
+        using var httpClient = new HttpClient(handler);
+        using var client = new OslcClient(httpClient, NullLogger<OslcClient>.Instance);
+        var parameters = new OslcQueryParameters();
+        parameters.SetWhere("dcterms:title=\"two words\"");
+        parameters.SetSelect("dcterms:title");
+        var query = new OslcQuery(
+            client,
+            "https://example.test/oslc/query",
+            25,
+            parameters);
+
+        await query.SubmitPost();
+
+        await Assert.That(capturedRequest).IsNotNull();
+        await Assert.That(capturedRequest!.Method).IsEqualTo(HttpMethod.Post);
+        await Assert.That(capturedRequest.RequestUri).IsEqualTo(new Uri("https://example.test/oslc/query"));
+        await Assert.That(capturedRequest.Content!.Headers.ContentType!.MediaType)
+            .IsEqualTo("application/x-www-form-urlencoded");
+        await Assert.That(capturedBody).Contains("oslc.where=dcterms%3Atitle%3D%22two%20words%22");
+        await Assert.That(capturedBody).DoesNotContain("%2520");
+        await Assert.That(capturedBody).Contains("oslc.pageSize=25");
+    }
+}


### PR DESCRIPTION
- Adds support for POST method in OSLC Queries
- Adds support for LDP-container specified membership predicates for OSLC Queries.
- Fixes the query total count parsing