### PR TITLE
server: provider: last ResponseInfo container page serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ This release does not remove any features.
 - Properties backed by URI collections are now reflected in OSLC shapes correctly (thanks to @ZUOXIANGE)
 - `OslcQueryResult` now handles cases where RDF graph parsing from query responses produces malformed URI nodes. Instead of throwing `ArgumentNullException`, methods like `GetMembersUrls()`, `GetMembers<T>()`, `GetNextPageUrl()`, and `GetTotalCount()` now gracefully return empty results or null values.
 - Replaced the use of `SystemException` with `InvalidOperationException` in `Property.cs` to resolve compiler warning CA2201.
+- `OslcRdfOutputFormatter` no longer throws on a `ResponseInfo` without a next page: a missing next page is kept as `null` instead of being coerced to an empty string that reached `new Uri("")`. Server-side OSLC query responses without paging now serialize correctly.
+- `DotNetRdfHelper.CreateDotNetRdfGraph` serializes an empty `ResponseInfo` container (a query that matched no members) instead of throwing when the `oslc` namespace prefix is not already registered.
 
 
 ## [0.6.3] - 2025-11-15

--- a/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/DotNetRdfHelper.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/DotNetRdfHelper.cs
@@ -132,7 +132,7 @@ public class DotNetRdfHelper(ILogger<DotNetRdfHelper> logger)
                     new Uri(OslcConstants.OSLC_CORE_NAMESPACE + PROPERTY_TOTAL_COUNT)),
                 graph.CreateLiteralNode(countValue.ToString(CultureInfo.InvariantCulture))));
 
-            if (nextPageAbout != null)
+            if (!string.IsNullOrEmpty(nextPageAbout))
             {
                 graph.Assert(new Triple(responseInfoResource,
                     graph.CreateUriNode(new Uri(OslcConstants.OSLC_CORE_NAMESPACE +
@@ -2027,7 +2027,10 @@ public class DotNetRdfHelper(ILogger<DotNetRdfHelper> logger)
     {
         var uri = new Uri(ns);
 
-        if (namespaceMappings.GetPrefix(uri) == null)
+        // INamespaceMapper.GetPrefix throws RdfException when the URI is not mapped, so it
+        // cannot be used as a presence check: a ResponseInfo container with no members (a
+        // valid empty query result) would never register the oslc prefix and would throw.
+        if (!namespaceMappings.TryGetPrefix(uri, out _))
         {
             if (!namespaceMappings.HasNamespace(prefix))
             {

--- a/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/Extensions.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core.DotNetRdfProvider/Extensions.cs
@@ -1,11 +1,34 @@
 using OSLC4Net.Core.Attribute;
 using OSLC4Net.Core.Exceptions;
 using OSLC4Net.Core.Model;
+using VDS.RDF;
 
 namespace OSLC4Net.Core.DotNetRdfProvider;
 
 public static class Extensions
 {
+    /// <summary>
+    /// Non-throwing alternative to <see cref="INamespaceMapper.GetPrefix"/>, which throws
+    /// <c>RdfException</c> when the namespace URI is not mapped.
+    /// </summary>
+    /// <returns><see langword="true"/> when <paramref name="uri"/> is mapped, with the
+    /// matching prefix in <paramref name="prefix"/>; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetPrefix(this INamespaceMapper namespaceMappings, Uri uri,
+        out string? prefix)
+    {
+        foreach (var existingPrefix in namespaceMappings.Prefixes)
+        {
+            if (namespaceMappings.GetNamespaceUri(existingPrefix).Equals(uri))
+            {
+                prefix = existingPrefix;
+                return true;
+            }
+        }
+
+        prefix = null;
+        return false;
+    }
+
     public static async Task<OslcCoreRequestException> ToOslcExceptionAsync(this
         HttpResponseMessage responseMessage, IResource? requestResource)
     {

--- a/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Server.Providers/OslcRdfOutputFormatter.cs
@@ -120,7 +120,10 @@ public class OslcRdfOutputFormatter : TextOutputFormatter
                 var totalCountProp = value.GetType().GetProperty("TotalCount");
                 var nextPageProp = value.GetType().GetProperty("NextPage");
 
-                var nextPageValue = nextPageProp?.GetValue(value, null) as string ?? string.Empty;
+                // A missing next page must stay null: passing string.Empty here makes
+                // CreateDotNetRdfGraph call new Uri(""), which throws for every non-paged query.
+                var nextPageRaw = nextPageProp?.GetValue(value, null) as string;
+                var nextPageValue = string.IsNullOrEmpty(nextPageRaw) ? null : nextPageRaw;
                 var totalCountValue = totalCountProp?.GetValue(value, null);
                 var totalCount = totalCountValue as int? ?? 0;
                 var propertiesValue =

--- a/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/ResponseInfoNextPageTests.cs
+++ b/OSLC4Net_SDK/Tests/OSLC4Net.Core.DotNetRdfProviderTests/ResponseInfoNextPageTests.cs
@@ -1,0 +1,66 @@
+using OSLC4Net.Core.DotNetRdfProvider;
+using VDS.RDF;
+
+namespace OSLC4Net.Core.DotNetRdfProviderTests;
+
+/// <summary>
+/// Regression tests for the ResponseInfo container: a missing next page must not
+/// produce an oslc:nextPage triple. OslcRdfOutputFormatter used to coerce a missing
+/// next page to string.Empty, which made CreateDotNetRdfGraph call new Uri("") and
+/// throw for every non-paged query.
+/// </summary>
+public class ResponseInfoNextPageTests
+{
+    private const string Description = "http://localhost/oslc/requirements";
+    private const string ResponseInfo = "http://localhost/oslc/requirements?oslc.where=x";
+    private const string NextPagePredicate = "http://open-services.net/ns/core#nextPage";
+    private const string TotalCountPredicate = "http://open-services.net/ns/core#totalCount";
+
+    [Test]
+    public async Task EmptyNextPage_DoesNotThrowAndOmitsNextPageTriple()
+    {
+        var graph = DotNetRdfHelper.CreateDotNetRdfGraph(
+            Description,
+            ResponseInfo,
+            nextPageAbout: string.Empty,
+            totalCount: 3,
+            objects: [],
+            properties: new Dictionary<string, object>(StringComparer.Ordinal));
+
+        await Assert.That(HasPredicate(graph, NextPagePredicate)).IsFalse();
+        await Assert.That(HasPredicate(graph, TotalCountPredicate)).IsTrue();
+    }
+
+    [Test]
+    public async Task NullNextPage_DoesNotThrowAndOmitsNextPageTriple()
+    {
+        var graph = DotNetRdfHelper.CreateDotNetRdfGraph(
+            Description,
+            ResponseInfo,
+            nextPageAbout: null,
+            totalCount: 3,
+            objects: [],
+            properties: new Dictionary<string, object>(StringComparer.Ordinal));
+
+        await Assert.That(HasPredicate(graph, NextPagePredicate)).IsFalse();
+    }
+
+    [Test]
+    public async Task NextPagePresent_EmitsNextPageTriple()
+    {
+        var nextPage = ResponseInfo + "&oslc.pageSize=10&page=2";
+
+        var graph = DotNetRdfHelper.CreateDotNetRdfGraph(
+            Description,
+            ResponseInfo,
+            nextPageAbout: nextPage,
+            totalCount: 20,
+            objects: [],
+            properties: new Dictionary<string, object>(StringComparer.Ordinal));
+
+        await Assert.That(HasPredicate(graph, NextPagePredicate)).IsTrue();
+    }
+
+    private static bool HasPredicate(IGraph graph, string predicate) =>
+        graph.GetTriplesWithPredicate(graph.CreateUriNode(new Uri(predicate))).Any();
+}


### PR DESCRIPTION
## Summary

Server-side OSLC query responses built as an `oslc:ResponseInfo` container could throw during serialization in two situations:

1. **No next page** — `OslcRdfOutputFormatter` read the `ResponseInfo.NextPage` property and coerced a missing value to `string.Empty`, then passed it to `DotNetRdfHelper.CreateDotNetRdfGraph`. The helper guards with `if (nextPageAbout != null)`, but `""` is not null, so it reached `new Uri("")` and threw — for **every non-paged query**.

2. **No members** — a valid query that matched nothing produces an empty member collection, so no resource ever registers the `oslc` namespace. `EnsureNamespacePrefix` then used `INamespaceMapper.GetPrefix(uri)` as a presence check, but that method **throws** `RdfException` for an unmapped URI rather than returning null, so the empty container threw before it could be emitted.

## Fix

- Keep a missing next page as `null` in the formatter (and harden the helper's guard to `!string.IsNullOrEmpty`), so no `oslc:nextPage` triple is emitted.
- Replace the throwing `GetPrefix` presence check with a non-throwing namespace lookup, so an empty `ResponseInfo` container serializes correctly.

## Tests

Adds `ResponseInfoNextPageTests` covering empty / null / present next page and the empty-member container. Full `OSLC4Net.Core.slnx` suite green (**82 passed, 1 skipped**).

## Context

Found while implementing server-side OSLC query support in [oslc-rm-strictdoc-dotnet#191](https://github.com/OSLC/oslc-rm-strictdoc-dotnet/pull/191), which currently works around this by calling `CreateDotNetRdfGraph` directly. Once this ships in a release, that workaround is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed pagination handling to correctly preserve missing next-page values as null instead of empty strings
  * Resolved serialization errors that occurred when RDF namespace prefixes were not pre-registered
  * Improved robustness of RDF graph generation for responses without pagination support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->