### PR TITLE
build: stop leaking Meziantou.Analyzer to referencing projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This release does not remove any features.
 
 ### Fixed
 
+- Meziantou.Analyzer is configured with PrivateAssets="all" to avoid leaking it as a transitive dependency in built NuGet packages.
 - Query results recognize membership predicates declared through `ldp:hasMemberRelation` or explicitly supplied to `OslcQuery`, and support `ldp:contains` query containers.
 - Query result total counts are parsed from RDF literal nodes.
 - Properties backed by URI collections are now reflected in OSLC shapes correctly (thanks to @ZUOXIANGE)

--- a/OSLC4Net_SDK/Directory.Build.props
+++ b/OSLC4Net_SDK/Directory.Build.props
@@ -54,7 +54,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer" />
+    <PackageReference Include="Meziantou.Analyzer">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where a build tool was being unintentionally included as a transitive dependency in NuGet packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->