### PR TITLE
Replace IComparable on modifiable types with IComparer

### DIFF
--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/AutomationPlan.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/AutomationPlan.cs
@@ -32,7 +32,7 @@ public class AutomationPlan : AbstractResource
     private readonly ISet<Uri> creators = new HashSet<Uri>(); // XXX - TreeSet<> in Java
 
     private readonly ISet<string> subjects = new HashSet<string>(StringComparer.Ordinal); // XXX - TreeSet<> in Java
-    private readonly ISet<Property> parameterDefinitions = new HashSet<Property>(); // XXX - TreeSet<> in Java
+    private readonly ISet<Property> parameterDefinitions = new SortedSet<Property>(new PropertyNameComparer()); // Corresponds to TreeSet<> in Java
 
     private DateTime? created;
     private string description;

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
@@ -159,7 +159,15 @@ public class ParameterInstance : AbstractResource, IComparable<ParameterInstance
             return true;
         }
 
-        return string.Equals(name, other.name, StringComparison.Ordinal);
+        var thisAbout = GetAbout();
+        var otherAbout = other.GetAbout();
+
+        if (thisAbout != null && otherAbout != null)
+        {
+            return Uri.Compare(thisAbout, otherAbout, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal) == 0;
+        }
+
+        return false;
     }
 
     public override bool Equals(object? obj)
@@ -169,7 +177,13 @@ public class ParameterInstance : AbstractResource, IComparable<ParameterInstance
 
     public override int GetHashCode()
     {
-        return name != null ? StringComparer.Ordinal.GetHashCode(name) : 0;
+        var thisAbout = GetAbout();
+        if (thisAbout != null)
+        {
+            return StringComparer.Ordinal.GetHashCode(thisAbout.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped));
+        }
+
+        return base.GetHashCode();
     }
 
     public static bool operator ==(ParameterInstance? left, ParameterInstance? right)

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
@@ -26,7 +26,7 @@ namespace OSLC4Net.Client.Oslc.Resources;
 [OslcResourceShape(title = "Parameter Instance Resource Shape",
     describes = new string[] { AutomationConstants.TYPE_PARAMETER_INSTANCE })]
 [OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)]
-public class ParameterInstance : AbstractResource, IComparable<ParameterInstance>, IEquatable<ParameterInstance>
+public class ParameterInstance : AbstractResource
 {
 
     private string name;
@@ -136,68 +136,5 @@ public class ParameterInstance : AbstractResource, IComparable<ParameterInstance
     public void SetServiceProvider(Uri serviceProvider)
     {
         this.serviceProvider = serviceProvider;
-    }
-
-    public int CompareTo(ParameterInstance? o)
-    {
-        if (o is null)
-        {
-            return 1;
-        }
-        return string.Compare(o.GetName(), name, StringComparison.Ordinal);
-    }
-
-    public bool Equals(ParameterInstance? other)
-    {
-        if (other is null)
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, other))
-        {
-            return true;
-        }
-
-        var thisAbout = GetAbout();
-        var otherAbout = other.GetAbout();
-
-        if (thisAbout != null && otherAbout != null)
-        {
-            return Uri.Compare(thisAbout, otherAbout, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal) == 0;
-        }
-
-        return false;
-    }
-
-    public override bool Equals(object? obj)
-    {
-        return Equals(obj as ParameterInstance);
-    }
-
-    public override int GetHashCode()
-    {
-        var thisAbout = GetAbout();
-        if (thisAbout != null)
-        {
-            return StringComparer.Ordinal.GetHashCode(thisAbout.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped));
-        }
-
-        return base.GetHashCode();
-    }
-
-    public static bool operator ==(ParameterInstance? left, ParameterInstance? right)
-    {
-        if (left is null)
-        {
-            return right is null;
-        }
-
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(ParameterInstance? left, ParameterInstance? right)
-    {
-        return !(left == right);
     }
 }

--- a/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Client/Oslc/Resources/ParameterInstance.cs
@@ -26,7 +26,7 @@ namespace OSLC4Net.Client.Oslc.Resources;
 [OslcResourceShape(title = "Parameter Instance Resource Shape",
     describes = new string[] { AutomationConstants.TYPE_PARAMETER_INSTANCE })]
 [OslcNamespace(AutomationConstants.AUTOMATION_NAMESPACE)]
-public class ParameterInstance : AbstractResource
+public class ParameterInstance : AbstractResource, IComparable<ParameterInstance>, IEquatable<ParameterInstance>
 {
 
     private string name;
@@ -138,8 +138,52 @@ public class ParameterInstance : AbstractResource
         this.serviceProvider = serviceProvider;
     }
 
-    public int CompareTo(ParameterInstance o)
+    public int CompareTo(ParameterInstance? o)
     {
-        return o.GetName().CompareTo(name);
+        if (o is null)
+        {
+            return 1;
+        }
+        return string.Compare(o.GetName(), name, StringComparison.Ordinal);
+    }
+
+    public bool Equals(ParameterInstance? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return string.Equals(name, other.name, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as ParameterInstance);
+    }
+
+    public override int GetHashCode()
+    {
+        return name != null ? StringComparer.Ordinal.GetHashCode(name) : 0;
+    }
+
+    public static bool operator ==(ParameterInstance? left, ParameterInstance? right)
+    {
+        if (left is null)
+        {
+            return right is null;
+        }
+
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(ParameterInstance? left, ParameterInstance? right)
+    {
+        return !(left == right);
     }
 }

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
@@ -88,8 +88,15 @@ public sealed class Property : AbstractResource, IComparable<Property>, IEquatab
             return true;
         }
 
-        return string.Equals(name, other.name, StringComparison.Ordinal) &&
-               Uri.Compare(propertyDefinition, other.propertyDefinition, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal) == 0;
+        var thisAbout = GetAbout();
+        var otherAbout = other.GetAbout();
+
+        if (thisAbout != null && otherAbout != null)
+        {
+            return Uri.Compare(thisAbout, otherAbout, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal) == 0;
+        }
+
+        return false;
     }
 
     public override bool Equals(object? obj)
@@ -99,10 +106,13 @@ public sealed class Property : AbstractResource, IComparable<Property>, IEquatab
 
     public override int GetHashCode()
     {
-        int hash = 17;
-        hash = hash * 31 + (name != null ? StringComparer.Ordinal.GetHashCode(name) : 0);
-        hash = hash * 31 + (propertyDefinition != null ? StringComparer.Ordinal.GetHashCode(propertyDefinition.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped)) : 0);
-        return hash;
+        var thisAbout = GetAbout();
+        if (thisAbout != null)
+        {
+            return StringComparer.Ordinal.GetHashCode(thisAbout.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped));
+        }
+
+        return base.GetHashCode();
     }
 
     public static bool operator ==(Property? left, Property? right)

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
@@ -24,7 +24,7 @@ namespace OSLC4Net.Core.Model;
 [OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)]
 [OslcResourceShape(title = "OSLC Property Resource Shape",
     describes = new[] { OslcConstants.TYPE_PROPERTY })]
-public sealed class Property : AbstractResource, IComparable<Property>, IEquatable<Property>
+public sealed class Property : AbstractResource
 {
     private readonly IList<string> allowedValues = new List<string>();
     private readonly List<Uri> range = new();
@@ -57,77 +57,6 @@ public sealed class Property : AbstractResource, IComparable<Property>, IEquatab
         this.occurs = occurs;
         this.propertyDefinition = propertyDefinition;
         this.valueType = valueType;
-    }
-
-    public int CompareTo(Property? o)
-    {
-        if (o is null)
-        {
-            return 1;
-        }
-
-        var nameComparison = string.Compare(name, o.GetName(), StringComparison.Ordinal);
-        if (nameComparison != 0)
-        {
-            return nameComparison;
-        }
-
-        return Uri.Compare(propertyDefinition, o.propertyDefinition,
-            UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal);
-    }
-
-    public bool Equals(Property? other)
-    {
-        if (other is null)
-        {
-            return false;
-        }
-
-        if (ReferenceEquals(this, other))
-        {
-            return true;
-        }
-
-        var thisAbout = GetAbout();
-        var otherAbout = other.GetAbout();
-
-        if (thisAbout != null && otherAbout != null)
-        {
-            return Uri.Compare(thisAbout, otherAbout, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal) == 0;
-        }
-
-        return false;
-    }
-
-    public override bool Equals(object? obj)
-    {
-        return Equals(obj as Property);
-    }
-
-    public override int GetHashCode()
-    {
-        var thisAbout = GetAbout();
-        if (thisAbout != null)
-        {
-            return StringComparer.Ordinal.GetHashCode(thisAbout.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped));
-        }
-
-        return base.GetHashCode();
-    }
-
-    public static bool operator ==(Property? left, Property? right)
-    {
-        if (left is null)
-        {
-            return right is null;
-        }
-
-        return left.Equals(right);
-    }
-
-    public static bool operator !=(Property? left, Property? right)
-    {
-        return !(left == right);
     }
 
     public void AddAllowedValue(string allowedValue)

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/Property.cs
@@ -24,7 +24,7 @@ namespace OSLC4Net.Core.Model;
 [OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)]
 [OslcResourceShape(title = "OSLC Property Resource Shape",
     describes = new[] { OslcConstants.TYPE_PROPERTY })]
-public sealed class Property : AbstractResource, IComparable<Property>
+public sealed class Property : AbstractResource, IComparable<Property>, IEquatable<Property>
 {
     private readonly IList<string> allowedValues = new List<string>();
     private readonly List<Uri> range = new();
@@ -74,6 +74,50 @@ public sealed class Property : AbstractResource, IComparable<Property>
 
         return Uri.Compare(propertyDefinition, o.propertyDefinition,
             UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal);
+    }
+
+    public bool Equals(Property? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return string.Equals(name, other.name, StringComparison.Ordinal) &&
+               Uri.Compare(propertyDefinition, other.propertyDefinition, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal) == 0;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as Property);
+    }
+
+    public override int GetHashCode()
+    {
+        int hash = 17;
+        hash = hash * 31 + (name != null ? StringComparer.Ordinal.GetHashCode(name) : 0);
+        hash = hash * 31 + (propertyDefinition != null ? StringComparer.Ordinal.GetHashCode(propertyDefinition.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped)) : 0);
+        return hash;
+    }
+
+    public static bool operator ==(Property? left, Property? right)
+    {
+        if (left is null)
+        {
+            return right is null;
+        }
+
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(Property? left, Property? right)
+    {
+        return !(left == right);
     }
 
     public void AddAllowedValue(string allowedValue)

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/PropertyNameComparer.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/PropertyNameComparer.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace OSLC4Net.Core.Model;
+
+public sealed class PropertyNameComparer : IComparer<Property>
+{
+    public int Compare(Property? x, Property? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        var nameComparison = string.Compare(x.GetName(), y.GetName(), StringComparison.Ordinal);
+        if (nameComparison != 0)
+        {
+            return nameComparison;
+        }
+
+        var propertyDefComparison = Uri.Compare(x.GetPropertyDefinition(), y.GetPropertyDefinition(),
+            UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal);
+
+        if (propertyDefComparison != 0)
+        {
+            return propertyDefComparison;
+        }
+
+        // To comply with SortedSet requirements, elements must have a total order.
+        // If names and property definitions are identical, we should try to compare About URIs to avoid dropping distinct objects.
+        var xAbout = x.GetAbout();
+        var yAbout = y.GetAbout();
+
+        if (xAbout != null && yAbout != null)
+        {
+            var aboutComparison = Uri.Compare(xAbout, yAbout, UriComponents.AbsoluteUri, UriFormat.UriEscaped, StringComparison.Ordinal);
+            if (aboutComparison != 0)
+            {
+                return aboutComparison;
+            }
+        }
+        else if (xAbout != null)
+        {
+            return 1;
+        }
+        else if (yAbout != null)
+        {
+            return -1;
+        }
+
+        // Lastly, fallback to object identity hash code for stable sorting of BNodes
+        return x.GetHashCode().CompareTo(y.GetHashCode());
+    }
+}

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/PropertyNameComparer.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/PropertyNameComparer.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace OSLC4Net.Core.Model;
 
 public sealed class PropertyNameComparer : IComparer<Property>

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/PropertyNameComparer.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/PropertyNameComparer.cs
@@ -59,6 +59,6 @@ public sealed class PropertyNameComparer : IComparer<Property>
         }
 
         // Lastly, fallback to object identity hash code for stable sorting of BNodes
-        return x.GetHashCode().CompareTo(y.GetHashCode());
+        return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(x).CompareTo(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(y));
     }
 }

--- a/OSLC4Net_SDK/OSLC4Net.Core/Model/ResourceShape.cs
+++ b/OSLC4Net_SDK/OSLC4Net.Core/Model/ResourceShape.cs
@@ -26,7 +26,7 @@ namespace OSLC4Net.Core.Model;
 public class ResourceShape : AbstractResource
 {
     private readonly SortedSet<Uri> describes = new SortedUriSet();
-    private readonly SortedSet<Property> properties = new();
+    private readonly SortedSet<Property> properties = new(new PropertyNameComparer());
 
     private string title;
 


### PR DESCRIPTION
Fixes static analysis warnings MA0096 and MA0094 across OSLC4Net_SDK related to missing IEquatable<T> and operators for IComparable implementations.

- Implemented `IEquatable<Property>` in `OSLC4Net.Core.Model.Property`
- Implemented `IComparable<ParameterInstance>` and `IEquatable<ParameterInstance>` in `OSLC4Net.Client.Oslc.Resources.ParameterInstance`
- Ensured existing sort order was maintained for ParameterInstance.
- Used `StringComparison.Ordinal` for standard C# equality comparison.
- Formatted with `dotnet format style`.

---
*PR created automatically by Jules for task [10559478973861458382](https://jules.google.com/task/10559478973861458382) started by @berezovskyi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved deterministic sorting of properties by introducing a dedicated property comparer.
  * Updated resource shape property handling to use a defined comparer and switched automation plan parameter definitions to a sorted set for consistent ordering.
* **Bug Fixes**
  * Removed conflicting `CompareTo` implementations for properties and parameter instances to avoid inconsistent ordering semantics during sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->