### PR TITLE
build: group .net runtime dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,19 @@ updates:
           - "xunit*"
           - "MSTest.*"
           - "Microsoft.NET.Test.*"
+      # Keep packages pinned to the .NET runtime version (10.0.x) together.
+      # Keep this list aligned with packages using $(DotnetRuntimeVersion).
+      dotnet-runtime-deps:
+        patterns:
+          - "Microsoft.AspNetCore.OpenApi"
+          - "Microsoft.AspNetCore.TestHost"
+          - "Microsoft.Extensions.Configuration.Json"
+          - "Microsoft.Extensions.DependencyInjection"
+          - "Microsoft.Extensions.Hosting"
+          - "Microsoft.Extensions.Hosting.Abstractions"
+          - "Microsoft.Extensions.Logging"
+          - "Microsoft.Extensions.Logging.Abstractions"
+          - "Microsoft.Extensions.Logging.Console"
       # often get updates in lockstep with dotnet
       test-ms-essential:
         patterns:

--- a/OSLC4Net_SDK/Directory.Packages.props
+++ b/OSLC4Net_SDK/Directory.Packages.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <AspireVersion>13.4.6</AspireVersion>
     <DotNetRdfVersion>3.5.2</DotNetRdfVersion>
-    <!-- Dependabot updates this value for the dotnet-runtime-deps group. -->
+    <!-- Update the dotnet-runtime-deps group when adding packages that use this variable. -->
     <DotnetRuntimeVersion>10.0.11</DotnetRuntimeVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/OSLC4Net_SDK/Directory.Packages.props
+++ b/OSLC4Net_SDK/Directory.Packages.props
@@ -6,6 +6,7 @@
   <PropertyGroup>
     <AspireVersion>13.4.6</AspireVersion>
     <DotNetRdfVersion>3.5.2</DotNetRdfVersion>
+    <!-- Dependabot updates this value for the dotnet-runtime-deps group. -->
     <DotnetRuntimeVersion>10.0.11</DotnetRuntimeVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

- group the nine packages pinned to `$(DotnetRuntimeVersion)` into one Dependabot pull request
- keep `Microsoft.Extensions.Http.Resilience` in the existing group because it uses `10.7.x`, not the `10.0.x` runtime numbering

## Validation

- parsed `.github/dependabot.yml` as YAML
- verified the group matches every `PackageVersion` using `$(DotnetRuntimeVersion)`
- pre-commit checks passed